### PR TITLE
Remove unused create-shots controls from timeline

### DIFF
--- a/loop/src/components/Timeline.tsx
+++ b/loop/src/components/Timeline.tsx
@@ -13,15 +13,10 @@ export const Timeline = ({
   onGenerate,
   activeTimeline,
   setActiveTimeline,
-  onCreateShots,
   isWeightingEnabled,
   onWeightingToggle,
   styleRigidity,
   onStyleRigidityChange,
-  selectedAssetIdForShots,
-  setSelectedAssetIdForShots,
-  isCreateShotsModalOpen,
-  setIsCreateShotsModalOpen,
   setIsOutputModalOpen,
   onOpenMultiShotModal,
   onOpenBatchStyleModal
@@ -34,15 +29,10 @@ export const Timeline = ({
   onGenerate: () => void;
   activeTimeline: 'primary' | 'secondary' | 'third' | 'fourth';
   setActiveTimeline: (timeline: 'primary' | 'secondary' | 'third' | 'fourth') => void;
-  onCreateShots: (assetId: string) => void;
   isWeightingEnabled: boolean;
   onWeightingToggle: (enabled: boolean) => void;
   styleRigidity: number;
   onStyleRigidityChange: (value: number) => void;
-  selectedAssetIdForShots: string | null;
-  setSelectedAssetIdForShots: (id: string | null) => void;
-  isCreateShotsModalOpen: boolean;
-  setIsCreateShotsModalOpen: (open: boolean) => void;
   setIsOutputModalOpen: (open: boolean) => void;
   onOpenMultiShotModal: () => void;
   onOpenBatchStyleModal: () => void;
@@ -351,24 +341,6 @@ const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?:
                     {asset.summary && (
                       <p className="text-sm ink-subtle mt-3">{asset.summary}</p>
                     )}
-                    <div className="flex justify-end mt-3">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setSelectedAssetIdForShots(asset.id);
-                          setIsCreateShotsModalOpen(true);
-                        }}
-                        className="timeline-action px-3 py-1.5 text-sm shadow-lg transform hover:scale-105 transition-all duration-200"
-                        style={{
-                          background: 'linear-gradient(145deg, #98FB98, #7AE67A)',
-                          boxShadow: '0 4px 8px rgba(152, 251, 152, 0.3), inset 0 1px 0 rgba(255,255,255,0.8)',
-                          border: '2px solid #7AE67A',
-                          color: '#2E8B57'
-                        }}
-                      >
-                        Create Shots
-                      </button>
-                    </div>
                   </div>
                 ))}
               </div>

--- a/loop/src/components/Workspace.tsx
+++ b/loop/src/components/Workspace.tsx
@@ -102,8 +102,6 @@ const Workspace: React.FC<WorkspaceProps> = ({
   const [isApiConfigOpen, setIsApiConfigOpen] = useState(false);
   const [isMultiShotModalOpen, setIsMultiShotModalOpen] = useState(false);
   const [isBatchStyleModalOpen, setIsBatchStyleModalOpen] = useState(false);
-  const [isCreateShotsModalOpen, setIsCreateShotsModalOpen] = useState(false);
-  const [selectedAssetIdForShots, setSelectedAssetIdForShots] = useState<string | null>(null);
   const [isOutputModalOpen, setIsOutputModalOpen] = useState(false);
   const [isMcpLoading, setIsMcpLoading] = useState(false);
   const [chatMessages, setChatMessages] = useState<Message[]>([]);
@@ -513,11 +511,6 @@ const Workspace: React.FC<WorkspaceProps> = ({
     });
   };
 
-  const handleCreateShots = (assetId: string) => {
-    setSelectedAssetIdForShots(assetId);
-    setIsCreateShotsModalOpen(true);
-  };
-
   const handleSyncAssetsToMcp = async () => {
     setIsMcpLoading(true);
     try {
@@ -569,15 +562,10 @@ const Workspace: React.FC<WorkspaceProps> = ({
               onGenerate={onGenerate}
               activeTimeline={activeTimeline}
               setActiveTimeline={setActiveTimeline}
-              onCreateShots={handleCreateShots}
               isWeightingEnabled={isWeightingEnabled}
               onWeightingToggle={onWeightingToggle}
               styleRigidity={styleRigidity}
               onStyleRigidityChange={onStyleRigidityChange}
-              selectedAssetIdForShots={selectedAssetIdForShots}
-              setSelectedAssetIdForShots={setSelectedAssetIdForShots}
-              isCreateShotsModalOpen={isCreateShotsModalOpen}
-              setIsCreateShotsModalOpen={setIsCreateShotsModalOpen}
               setIsOutputModalOpen={setIsOutputModalOpen}
               onOpenMultiShotModal={handleOpenMultiShotModal}
               onOpenBatchStyleModal={handleOpenBatchStyleModal}


### PR DESCRIPTION
## Summary
- remove the Create Shots button from the timeline master story assets section
- drop unused props from the Timeline component and related state/helpers in Workspace

## Testing
- npm run build --prefix loop
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e3736e200483268de0ad94ff392b4a