### PR TITLE
Refine style weighting controls

### DIFF
--- a/loop/src/App.tsx
+++ b/loop/src/App.tsx
@@ -51,7 +51,7 @@ const App: React.FC = () => {
     handleGenerateOutput
   } = useProject(initialProject);
 
-  // Global state for Tag Weighting System
+  // Global state for Style Weighting System
   const [tagWeights, setTagWeights] = useState<Record<string, number>>({});
   const [styleRigidity, setStyleRigidity] = useState<number>(50);
   const [isWeightingEnabled, setIsWeightingEnabled] = useState<boolean>(false);

--- a/loop/src/components/ContextPanel.tsx
+++ b/loop/src/components/ContextPanel.tsx
@@ -124,8 +124,11 @@ const WeightsView: React.FC<Omit<ContextPanelProps, 'mode' | 'buildContext' | 's
             <div className="panel-section p-3">
                 <div className="flex justify-between items-center">
                     <div className="flex items-center gap-2">
-                        <label htmlFor="enable-weighting" className="font-bold ink-strong">Enable Tag Weighting</label>
-                        <QuestionMarkCircleIcon className="w-4 h-4 opacity-70" title="Weighting help" />
+                        <label htmlFor="enable-weighting" className="font-bold ink-strong">Enable Style Weighting</label>
+                        <QuestionMarkCircleIcon
+                            className="w-4 h-4 opacity-70"
+                            title="Style weighting lets you prioritize adherence to your selected references."
+                        />
                     </div>
                     <button
                         role="switch"
@@ -145,20 +148,30 @@ const WeightsView: React.FC<Omit<ContextPanelProps, 'mode' | 'buildContext' | 's
 
             <div className={`transition-opacity duration-300 ${isWeightingEnabled ? 'opacity-100' : 'opacity-50 pointer-events-none'}`}>
                  <div className="panel-section p-3 mb-4">
-                    <label htmlFor="style-rigidity" className="block font-bold ink-strong mb-2">Style Rigidity</label>
-                    <input
-                        id="style-rigidity"
-                        type="range"
-                        min="0"
-                        max="100"
-                        value={styleRigidity}
-                        onChange={(e) => onStyleRigidityChange?.(parseInt(e.target.value, 10))}
-                        className="w-full"
-                        disabled={!isWeightingEnabled}
-                    />
-                     <div className="text-xs ink-subtle flex justify-between">
-                        <span>More AI Freedom</span>
-                        <span>Strict Adherence</span>
+                    <label htmlFor="style-rigidity" className="block font-bold ink-strong">Style Rigidity</label>
+                    <div className="mt-2">
+                        <div className="relative">
+                            <input
+                                id="style-rigidity"
+                                type="range"
+                                min="0"
+                                max="100"
+                                value={styleRigidity ?? 0}
+                                onChange={(e) => onStyleRigidityChange?.(parseInt(e.target.value, 10))}
+                                className="w-full h-1 rounded-full appearance-none cursor-pointer"
+                                style={{
+                                    background: `linear-gradient(to right, hsl(var(--primary)) 0%, hsl(var(--primary)) ${styleRigidity ?? 0}%, rgba(255,255,255,0.3) ${styleRigidity ?? 0}%, rgba(255,255,255,0.3) 100%)`
+                                }}
+                                disabled={!isWeightingEnabled}
+                            />
+                            <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                                <span className="w-px h-3 bg-white/70 rounded-full" />
+                            </div>
+                        </div>
+                        <div className="text-[10px] ink-subtle flex justify-between uppercase tracking-wide mt-1">
+                            <span>Creativity</span>
+                            <span>Adherence</span>
+                        </div>
                     </div>
                 </div>
 
@@ -203,12 +216,12 @@ const ContextPanel: React.FC<ContextPanelProps> = (props) => {
   const TABS = {
       build: [
           {id: 'seeds', label: 'Project Seeds'},
-          {id: 'weights', label: 'Tag Weights'},
+          {id: 'weights', label: 'Style Weights'},
           {id: 'knowledge', label: 'Knowledge'}
       ],
       sandbox: [
           {id: 'tags', label: 'Sandbox Context'},
-          {id: 'weights', label: 'Tag Weights'},
+          {id: 'weights', label: 'Style Weights'},
           {id: 'knowledge', label: 'Knowledge'}
       ]
   };

--- a/loop/src/components/Timeline.tsx
+++ b/loop/src/components/Timeline.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Asset, Project, TimelineBlock } from '../types';
 import { ASSET_TEMPLATES } from '../constants';
-import { MagicWandIcon, PlusIcon, SparklesIcon } from './IconComponents';
+import { MagicWandIcon, PlusIcon, QuestionMarkCircleIcon, SparklesIcon } from './IconComponents';
 
 // @ts-ignore
 export const Timeline = ({
@@ -239,7 +239,18 @@ const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?:
         <div className="flex justify-center">
           <div className="p-2 max-w-lg w-full bg-white/10 rounded-full backdrop-blur-sm border border-white/20">
             <div className="flex items-center gap-2 px-2">
-              <label htmlFor="weighting-enabled-timeline" className="text-xs font-medium ink-strong whitespace-nowrap">Tag</label>
+              <div className="flex items-center gap-1">
+                <label
+                  htmlFor="weighting-enabled-timeline"
+                  className="text-xs font-medium ink-strong whitespace-nowrap"
+                >
+                  Style Weighting
+                </label>
+                <QuestionMarkCircleIcon
+                  className="w-3.5 h-3.5 opacity-70"
+                  title="Style weighting balances AI creativity with adherence to your selected references."
+                />
+              </div>
               <button
                 role="switch"
                 aria-checked={isWeightingEnabled}
@@ -250,22 +261,39 @@ const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?:
                 <span className={`inline-block h-2.5 w-2.5 transform rounded-full toggle-thumb ${isWeightingEnabled ? 'translate-x-4' : 'translate-x-1'}`} />
               </button>
               
-              <div className={`flex items-center gap-2 flex-1 ${isWeightingEnabled ? 'opacity-100' : 'opacity-50 pointer-events-none'}`}>
-                <label htmlFor="style-rigidity-timeline" className="text-xs ink-strong whitespace-nowrap">Style</label>
-                <input
-                  id="style-rigidity-timeline"
-                  type="range"
-                  min="0"
-                  max="100"
-                  value={styleRigidity}
-                  onChange={(e) => onStyleRigidityChange(parseInt(e.target.value, 10))}
-                  className="flex-1 h-1 bg-white/30 rounded-full appearance-none cursor-pointer"
-                  style={{
-                    background: `linear-gradient(to right, hsl(var(--primary)) 0%, hsl(var(--primary)) ${styleRigidity}%, rgba(255,255,255,0.3) ${styleRigidity}%, rgba(255,255,255,0.3) 100%)`
-                  }}
-                  disabled={!isWeightingEnabled}
-                />
-                <span className="text-xs ink-subtle min-w-[2rem] text-center">{styleRigidity}%</span>
+              <div className={`flex items-start gap-3 flex-1 ${isWeightingEnabled ? 'opacity-100' : 'opacity-50 pointer-events-none'}`}>
+                <div className="flex-1">
+                  <div className="flex items-center gap-1">
+                    <label htmlFor="style-rigidity-timeline" className="text-xs ink-strong whitespace-nowrap">
+                      Style Rigidity
+                    </label>
+                  </div>
+                  <div className="mt-1">
+                    <div className="relative">
+                      <input
+                        id="style-rigidity-timeline"
+                        type="range"
+                        min="0"
+                        max="100"
+                        value={styleRigidity}
+                        onChange={(e) => onStyleRigidityChange(parseInt(e.target.value, 10))}
+                        className="w-full h-1 bg-white/30 rounded-full appearance-none cursor-pointer"
+                        style={{
+                          background: `linear-gradient(to right, hsl(var(--primary)) 0%, hsl(var(--primary)) ${styleRigidity}%, rgba(255,255,255,0.3) ${styleRigidity}%, rgba(255,255,255,0.3) 100%)`
+                        }}
+                        disabled={!isWeightingEnabled}
+                      />
+                      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                        <span className="w-px h-3 bg-white/70 rounded-full" />
+                      </div>
+                    </div>
+                    <div className="flex justify-between text-[10px] uppercase ink-subtle tracking-wide mt-1">
+                      <span>Creativity</span>
+                      <span>Adherence</span>
+                    </div>
+                  </div>
+                </div>
+                <span className="text-xs ink-subtle min-w-[2.5rem] text-right">{styleRigidity}%</span>
               </div>
             </div>
           </div>

--- a/loop/src/components/UserGuide.tsx
+++ b/loop/src/components/UserGuide.tsx
@@ -312,7 +312,7 @@ const UserGuide: React.FC<UserGuideProps> = ({ isOpen, onClose }) => {
                   Select any block to open the frosted inspector on the right. Adjust fields with dropdowns, fine-tune weights, or add tags without losing seed lineage.
                 </p>
                 <p className="text-sm ink-subtle leading-relaxed">
-                  The Control deck beneath lets you toggle Tag Weighting, tweak Style Rigidity, and trigger Generate for rapid iterations.
+                  The Control deck beneath lets you toggle Style Weighting, tweak Style Rigidity, and trigger Generate for rapid iterations.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- rename the timeline toggle to "Style Weighting", add helper context, and add creativity/adherence captions with a center marker to the slider
- update the context panel to match the new terminology and slider styling across build and sandbox tabs
- refresh related copy to keep "Style Weighting" wording consistent throughout the UI and docs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e607fd30bc8326ac58e6ad06592413