### PR TITLE
Refresh chat assistant controls with Infinity Loop iconography

### DIFF
--- a/loop/src/components/ChatAssistant.tsx
+++ b/loop/src/components/ChatAssistant.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect, useMemo } from 'react';
 import type { Message } from '../types';
 import { ChatRole } from '../types';
 import LoadingSpinner from './LoadingSpinner';
-import { SendIcon, SparklesIcon, UserIcon, MagicWandIcon, CubeTransparentIcon } from './IconComponents';
+import { SendIcon, LoopSparkIcon, LoopPersonaIcon, LoopCatalystIcon, LoopConstructIcon } from './IconComponents';
 import { knowledgeBase } from '../services/knowledgeService';
 
 interface ChatAssistantProps {
@@ -537,7 +537,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
           {showMockNotice && (
             <div className="flex items-start gap-3 rounded-xl border border-indigo-500/40 bg-indigo-500/10 p-4 text-indigo-100">
               <div className="w-8 h-8 rounded-full bg-indigo-500/60 flex items-center justify-center flex-shrink-0 mt-0.5">
-                <SparklesIcon className="w-5 h-5" />
+                <LoopSparkIcon className="w-5 h-5" />
               </div>
               <div className="flex-1 space-y-1">
                 <p className="font-semibold text-indigo-100">Mock mode active</p>
@@ -565,7 +565,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
                   className="w-8 h-8 rounded-full chat-avatar flex items-center justify-center flex-shrink-0"
                   style={getFeatureStyles(currentBuild || 'menu')}
                 >
-                  <SparklesIcon className="w-5 h-5" />
+                  <LoopSparkIcon className="w-5 h-5" />
                 </div>
               )}
 
@@ -586,7 +586,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
 
               {msg.role === ChatRole.USER && (
                 <div className="w-8 h-8 rounded-full chat-avatar chat-avatar--user flex items-center justify-center flex-shrink-0">
-                  <UserIcon className="w-5 h-5" />
+                  <LoopPersonaIcon className="w-5 h-5" />
                 </div>
               )}
             </div>
@@ -598,7 +598,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
                 className="w-8 h-8 rounded-full chat-avatar flex items-center justify-center flex-shrink-0"
                 style={getFeatureStyles(currentBuild || 'menu')}
               >
-                <SparklesIcon className="w-5 h-5" />
+                <LoopSparkIcon className="w-5 h-5" />
               </div>
               <div
                 className="max-w-none w-full p-4 chat-bubble chat-bubble--model chat-bubble--generated"
@@ -615,7 +615,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
                 className="w-8 h-8 rounded-full chat-avatar flex items-center justify-center flex-shrink-0"
                 style={getFeatureStyles(currentBuild || 'menu')}
               >
-                  <SparklesIcon className="w-5 h-5 animate-pulse" />
+                  <LoopSparkIcon className="w-5 h-5 animate-pulse" />
               </div>
               <div className="max-w-xl p-4 chat-bubble chat-bubble--model">
                 <LoadingSpinner />
@@ -994,7 +994,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
               aria-label="Timeline workflow"
               title="Start timeline asset propagation workflow"
             >
-              <MagicWandIcon className="w-5 h-5" />
+              <LoopCatalystIcon className="w-5 h-5" />
             </button>
             <button
               type="button"
@@ -1004,7 +1004,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
               aria-label="Smart generation"
               title="Generate based on current timeline context"
             >
-              <SparklesIcon className="w-5 h-5" />
+              <LoopSparkIcon className="w-5 h-5" />
             </button>
             <button
               type="button"
@@ -1014,7 +1014,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
               aria-label="Iterate master asset"
               title="Iterate Master Story & Visual Assets"
             >
-              <CubeTransparentIcon className="w-5 h-5" />
+              <LoopConstructIcon className="w-5 h-5" />
             </button>
             <button
               type="button"
@@ -1024,7 +1024,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
               aria-label="Create Multi-Shot"
               title="Create Multi-Shot from Master Assets"
             >
-              <UserIcon className="w-5 h-5" />
+              <LoopPersonaIcon className="w-5 h-5" />
             </button>
             <button
               type="button"
@@ -1033,7 +1033,7 @@ const ChatAssistant: React.FC<ChatAssistantProps> = ({
               style={getFeatureStyles('menu')}
               aria-label="Build menu"
             >
-              <UserIcon className="w-5 h-5" />
+              <LoopPersonaIcon className="w-5 h-5" />
             </button>
             <button
               type="submit"

--- a/loop/src/components/IconComponents.tsx
+++ b/loop/src/components/IconComponents.tsx
@@ -70,6 +70,201 @@ export const FracturedLoopLogo: React.FC<IconProps> = ({ className, title }) => 
   );
 };
 
+const loopGradientStops = (
+  <>
+    <stop offset="0%" stopColor="hsl(var(--secondary))" />
+    <stop offset="50%" stopColor="hsl(var(--primary))" />
+    <stop offset="100%" stopColor="hsl(var(--accent))" />
+  </>
+);
+
+export const LoopCatalystIcon: React.FC<IconProps> = ({ className, title }) => {
+  const gradientId = React.useId();
+  const loopId = `${gradientId}-loop`;
+  const glowId = `${gradientId}-glow`;
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      focusable="false"
+      {...getAccessibilityProps(title)}
+    >
+      {renderTitle(title)}
+      <defs>
+        <linearGradient id={loopId} x1="0%" y1="0%" x2="100%" y2="100%">
+          {loopGradientStops}
+        </linearGradient>
+        <radialGradient id={glowId} cx="50%" cy="50%" r="60%">
+          <stop offset="0%" stopColor="hsl(var(--chat-highlight, var(--muted)))" stopOpacity="0.9" />
+          <stop offset="100%" stopColor="transparent" />
+        </radialGradient>
+      </defs>
+      <g fill="none" strokeLinecap="round" strokeLinejoin="round">
+        <path
+          d="M6.6 9.6c1.1-1.1 2.8-1.1 3.9 0l.9.9.9-.9c1.1-1.1 2.8-1.1 3.9 0s1.1 2.9 0 4-2.8 1.1-3.9 0l-.9-.9-.9.9c-1.1 1.1-2.8 1.1-3.9 0s-1.1-2.9 0-4z"
+          stroke={`url(#${loopId})`}
+          strokeWidth="1.6"
+        />
+        <path
+          d="M6.2 14.1c-.6-1.6-.2-3.4 1.1-4.7"
+          stroke="hsl(var(--card))"
+          strokeWidth="0.9"
+          opacity="0.85"
+        />
+        <path
+          d="M17.8 9.4c1.3 1.3 1.7 3.1 1.1 4.7"
+          stroke="hsl(var(--card))"
+          strokeWidth="0.9"
+          opacity="0.85"
+        />
+        <path d="M4.2 18.6l5.7-5.7" stroke={`url(#${loopId})`} strokeWidth="1.5" />
+        <path d="M5.5 19.8l6.5-6.5" stroke="hsl(var(--card))" strokeWidth="1" opacity="0.75" />
+        <circle cx="4.9" cy="6.1" r="1.2" fill={`url(#${glowId})`} />
+        <path d="M4.9 4.2l.4 1.3 1.3.4-1.3.4-.4 1.3-.4-1.3-1.3-.4 1.3-.4z" fill={`url(#${loopId})`} />
+      </g>
+    </svg>
+  );
+};
+
+export const LoopSparkIcon: React.FC<IconProps> = ({ className, title }) => {
+  const gradientId = React.useId();
+  const loopId = `${gradientId}-loop`;
+  const sparkId = `${gradientId}-spark`;
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      focusable="false"
+      {...getAccessibilityProps(title)}
+    >
+      {renderTitle(title)}
+      <defs>
+        <linearGradient id={loopId} x1="0%" y1="0%" x2="100%" y2="100%">
+          {loopGradientStops}
+        </linearGradient>
+        <radialGradient id={sparkId} cx="50%" cy="50%" r="55%">
+          <stop offset="0%" stopColor="hsl(var(--accent))" stopOpacity="0.95" />
+          <stop offset="70%" stopColor="hsl(var(--primary))" stopOpacity="0.45" />
+          <stop offset="100%" stopColor="transparent" />
+        </radialGradient>
+      </defs>
+      <g fill="none" strokeLinecap="round" strokeLinejoin="round">
+        <path
+          d="M6.3 10c1-1.3 2.9-1.5 4.1-.3l1 1 1-1c1.2-1.2 3.1-1 4.1.3 1.1 1.3 1 3.2-.2 4.3-1.2 1.2-3.1 1.2-4.3 0l-.6-.6-.6.6c-1.2 1.2-3.1 1.2-4.3 0-1.2-1.1-1.3-3-.2-4.3z"
+          stroke={`url(#${loopId})`}
+          strokeWidth="1.5"
+        />
+        <path
+          d="M12 3.3l.9 2.6 2.5.9-2.5.9-.9 2.6-.9-2.6-2.5-.9 2.5-.9z"
+          fill={`url(#${sparkId})`}
+          stroke={`url(#${loopId})`}
+          strokeWidth="1"
+        />
+        <path d="M12 7.6v3.1" stroke="hsl(var(--card))" strokeWidth="1" />
+        <path d="M9.6 16.3l-1.8 2.8" stroke="hsl(var(--card))" strokeWidth="0.9" opacity="0.8" />
+        <path d="M14.4 16.3l1.8 2.8" stroke="hsl(var(--card))" strokeWidth="0.9" opacity="0.8" />
+        <circle cx="12" cy="12" r="1.8" fill={`url(#${sparkId})`} opacity="0.9" />
+      </g>
+    </svg>
+  );
+};
+
+export const LoopConstructIcon: React.FC<IconProps> = ({ className, title }) => {
+  const gradientId = React.useId();
+  const loopId = `${gradientId}-loop`;
+  const panelId = `${gradientId}-panel`;
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      focusable="false"
+      {...getAccessibilityProps(title)}
+    >
+      {renderTitle(title)}
+      <defs>
+        <linearGradient id={loopId} x1="0%" y1="0%" x2="100%" y2="100%">
+          {loopGradientStops}
+        </linearGradient>
+        <linearGradient id={panelId} x1="20%" y1="0%" x2="80%" y2="100%">
+          <stop offset="0%" stopColor="hsl(var(--card))" />
+          <stop offset="100%" stopColor="hsl(var(--secondary))" />
+        </linearGradient>
+      </defs>
+      <g fill="none" strokeLinecap="round" strokeLinejoin="round">
+        <path
+          d="M6.4 10.1c1.1-1.3 3-1.5 4.3-.4l1.3 1.1 1.3-1.1c1.3-1.1 3.2-.9 4.3.4 1.1 1.3.9 3.3-.4 4.4-1.3 1.1-3.1 1.1-4.3-.1l-.9-.8-.9.8c-1.2 1.2-3 .1-4.3.1-1.3-1.1-1.5-3.1-.4-4.4z"
+          stroke={`url(#${loopId})`}
+          strokeWidth="1.6"
+        />
+        <path
+          d="M9.8 9.7l2.2-1.2 2.2 1.2v2.4l-2.2 1.2-2.2-1.2z"
+          fill={`url(#${panelId})`}
+          stroke="hsl(var(--ink))"
+          strokeWidth="0.9"
+        />
+        <path d="M9.8 12.1v2.4l2.2 1.2 2.2-1.2v-2.4" stroke="hsl(var(--card))" strokeWidth="0.9" />
+        <path d="M8.4 16.3l3.6 2.1 3.6-2.1" stroke={`url(#${loopId})`} strokeWidth="1.1" />
+        <path d="M7.2 11.6l-1.4-.8" stroke="hsl(var(--card))" strokeWidth="0.9" opacity="0.8" />
+        <path d="M16.8 11.6l1.4-.8" stroke="hsl(var(--card))" strokeWidth="0.9" opacity="0.8" />
+      </g>
+    </svg>
+  );
+};
+
+export const LoopPersonaIcon: React.FC<IconProps> = ({ className, title }) => {
+  const gradientId = React.useId();
+  const loopId = `${gradientId}-loop`;
+  const fillId = `${gradientId}-fill`;
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      focusable="false"
+      {...getAccessibilityProps(title)}
+    >
+      {renderTitle(title)}
+      <defs>
+        <linearGradient id={loopId} x1="0%" y1="0%" x2="100%" y2="100%">
+          {loopGradientStops}
+        </linearGradient>
+        <linearGradient id={fillId} x1="40%" y1="0%" x2="60%" y2="100%">
+          <stop offset="0%" stopColor="hsl(var(--card))" />
+          <stop offset="100%" stopColor="hsl(var(--secondary))" />
+        </linearGradient>
+      </defs>
+      <g fill="none" strokeLinecap="round" strokeLinejoin="round">
+        <path
+          d="M6.1 10.1c1-1.4 3-1.8 4.5-.8l1.4.9 1.4-.9c1.5-1 3.5-.6 4.5.8 1 1.4.7 3.3-.7 4.3-1.4 1-3.1.8-4.3-.4l-.9-.9-.9.9c-1.2 1.2-2.9 1.4-4.3.4-1.4-1-1.7-2.9-.7-4.3z"
+          stroke={`url(#${loopId})`}
+          strokeWidth="1.5"
+        />
+        <path
+          d="M12 7.2a2.7 2.7 0 110 5.4 2.7 2.7 0 010-5.4z"
+          fill={`url(#${fillId})`}
+          stroke="hsl(var(--ink))"
+          strokeWidth="0.9"
+        />
+        <path
+          d="M7.2 17.4c.4-2.2 2.3-3.8 4.8-3.8s4.4 1.6 4.8 3.8"
+          stroke={`url(#${loopId})`}
+          strokeWidth="1.1"
+        />
+        <path
+          d="M9 17.2c.3-1.2 1.5-2.1 3-2.1s2.7.9 3 2.1"
+          stroke="hsl(var(--card))"
+          strokeWidth="0.9"
+        />
+        <circle cx="6" cy="7.6" r="0.9" fill={`url(#${loopId})`} />
+        <circle cx="18" cy="7.2" r="0.7" fill={`url(#${loopId})`} opacity="0.7" />
+      </g>
+    </svg>
+  );
+};
+
 export const ChatBubbleLeftRightIcon: React.FC<IconProps> = ({ className, title }) => {
   const gradientId = React.useId();
   const fillId = `${gradientId}-chat-fill`;

--- a/loop/src/index.css
+++ b/loop/src/index.css
@@ -1725,32 +1725,54 @@ textarea:focus-visible {
 
 .chat-icon-button {
   align-items: center;
-  background: transparent;
+  background:
+      radial-gradient(circle at 18% 20%, hsl(var(--chat-highlight, var(--muted)) / 0.75) 0%, transparent 55%),
+      radial-gradient(circle at 80% 80%, hsl(var(--chat-edge, var(--ring)) / 0.2) 0%, transparent 65%),
+      linear-gradient(145deg, hsl(var(--chat-surface, var(--card)) / 0.88) 0%, hsl(var(--chat-highlight, var(--muted)) / 0.95) 55%, hsl(var(--chat-edge, var(--ring)) / 0.65) 100%);
   border-radius: 9999px;
-  border: 1px solid transparent;
+  border: 1px solid hsl(var(--chat-edge, var(--ring)) / 0.4);
   color: hsl(var(--muted-foreground));
   display: inline-flex;
   justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, background 0.2s ease;
+  box-shadow:
+    0 10px 24px hsl(var(--chat-accent, var(--primary)) / 0.24),
+    0 2px 6px hsl(var(--ink) / 0.08),
+    inset 0 2px 3px hsl(var(--chat-highlight, var(--muted)) / 0.85),
+    inset 0 -3px 6px hsl(var(--chat-edge, var(--ring)) / 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
 .chat-icon-button:hover:not(:disabled) {
-  background: hsl(var(--chat-accent, var(--primary)) / 0.18);
+  transform: translateY(-1px);
+  background:
+      radial-gradient(circle at 22% 22%, hsl(var(--chat-highlight, var(--muted)) / 0.9) 0%, transparent 60%),
+      radial-gradient(circle at 78% 78%, hsl(var(--chat-accent, var(--primary)) / 0.3) 0%, transparent 70%),
+      linear-gradient(150deg, hsl(var(--chat-surface, var(--card)) / 0.95) 0%, hsl(var(--chat-highlight, var(--muted)) / 1) 55%, hsl(var(--chat-accent, var(--primary)) / 0.75) 100%);
   color: hsl(var(--chat-accent, var(--primary)));
-  box-shadow: 0 12px 32px hsl(var(--chat-accent, var(--primary)) / 0.28);
-  outline: 1px solid hsl(var(--ink) / 0.25);
+  border-color: hsl(var(--chat-accent, var(--primary)) / 0.55);
+  box-shadow:
+    0 14px 32px hsl(var(--chat-accent, var(--primary)) / 0.32),
+    0 4px 12px hsl(var(--ink) / 0.12),
+    inset 0 3px 6px hsl(var(--chat-highlight, var(--muted)) / 0.95),
+    inset 0 -3px 8px hsl(var(--chat-accent, var(--primary)) / 0.45);
 }
 
 .chat-icon-button:focus-visible {
   outline: 2px solid hsl(var(--ink));
   outline-offset: 2px;
-  box-shadow: 0 0 0 4px hsl(var(--chat-accent, var(--primary)) / 0.25);
+  border-color: hsl(var(--ink));
+  box-shadow:
+    0 0 0 4px hsl(var(--chat-accent, var(--primary)) / 0.28),
+    0 12px 28px hsl(var(--chat-accent, var(--primary)) / 0.28),
+    inset 0 2px 4px hsl(var(--chat-highlight, var(--muted)) / 0.9);
 }
 
 .chat-icon-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
   box-shadow: none;
+  background: linear-gradient(145deg, hsl(var(--chat-surface, var(--card)) / 0.75), hsl(var(--chat-surface, var(--card)) / 0.85));
+  border-color: hsl(var(--chat-edge, var(--ring)) / 0.25);
 }
 
 .chat-meta {


### PR DESCRIPTION
## Summary
- add Infinity Loop themed icon variants to the shared icon library for workflow, spark, construct, and persona actions
- update the chat assistant to use the new branded icons and preserve accessible hover and focus behavior
- restyle chat icon buttons with layered gradients, inset highlights, and drop shadows for a three-dimensional feel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e607e4e964832689e06b726b41886e