### PR TITLE
Anchor multi-shot and batch style modals in timeline

### DIFF
--- a/loop/src/components/BatchStyleModal.tsx
+++ b/loop/src/components/BatchStyleModal.tsx
@@ -8,7 +8,7 @@ interface BatchStyleModalProps {
   selectedMasterImage: string | null;
   onToggleMultiShot: (assetId: string) => void;
   onSelectMasterImage: (assetId: string) => void;
-  onConfirm: () => void;
+  onConfirm: () => boolean | void;
   onCancel: () => void;
 }
 
@@ -105,7 +105,7 @@ export const BatchStyleModal: React.FC<BatchStyleModalProps> = ({
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
-        style={{ maxWidth: '800px', maxHeight: '90vh' }}
+        style={{ maxWidth: '95vw', width: '1400px', maxHeight: '95vh', minHeight: '720px' }}
       >
         <div className="glass-modal__header">
           <h2 id={titleId} className="glass-modal__title ink-strong">Create Batch Style Application</h2>
@@ -114,35 +114,41 @@ export const BatchStyleModal: React.FC<BatchStyleModalProps> = ({
           Select multi-shot assets and a master image to apply consistent visual styling across all shots in one batch operation.
         </p>
 
-        <div className="flex-1 overflow-y-auto custom-scrollbar" style={{ maxHeight: 'calc(90vh - 250px)' }}>
+        <div
+          className="flex-1 overflow-y-auto custom-scrollbar px-8 py-6 space-y-8"
+          style={{ maxHeight: 'calc(95vh - 220px)' }}
+        >
           {/* Multi-Shot Selection */}
-          <div className="p-4 border-b border-white/20">
-            <h3 className="font-medium ink-strong mb-3 flex items-center gap-2">
-              <span className="inline-block w-6 h-6 bg-blue-500 text-white rounded-full text-center text-sm leading-6">1</span>
+          <div className="border border-blue-300/40 bg-blue-500/10 rounded-2xl p-6 space-y-4">
+            <h3 className="font-medium ink-strong flex items-center gap-3 text-base">
+              <span className="inline-flex w-8 h-8 items-center justify-center bg-blue-500 text-white rounded-full text-sm">1</span>
               Select Multi-Shot Assets
             </h3>
-            <p className="text-xs ink-subtle mb-3">Choose one or more multi-shot assets to apply styling to.</p>
+            <p className="text-sm ink-subtle">Choose one or more multi-shot assets to apply styling to.</p>
             {multiShotAssets.length === 0 ? (
-              <p className="text-sm ink-subtle text-center py-4 bg-white/5 rounded-lg">
+              <p className="text-sm ink-subtle text-center py-6 bg-white/10 rounded-xl">
                 No multi-shot assets available. Create multi-shot assets first from the Multi-Shot panel.
               </p>
             ) : (
-              <div className="space-y-2">
+              <div className="max-h-72 overflow-y-auto custom-scrollbar space-y-3 pr-2">
                 {multiShotAssets.map(asset => (
-                  <label key={asset.id} className="flex items-start gap-3 p-3 cursor-pointer hover:bg-white/5 rounded-lg transition-colors border border-blue-200">
+                  <label
+                    key={asset.id}
+                    className="flex items-start gap-4 p-4 cursor-pointer hover:bg-white/10 rounded-xl transition-colors border border-blue-200/60"
+                  >
                     <input
                       type="checkbox"
                       checked={selectedMultiShots.includes(asset.id)}
                       onChange={() => onToggleMultiShot(asset.id)}
                       className="mt-1"
                     />
-                    <div className="flex-1">
-                      <div className="font-medium ink-strong">{asset.name}</div>
-                      <div className="text-xs ink-subtle mt-1">
-                        Seed: {asset.seedId.slice(0, 8)}... | Shots: {asset.metadata?.configuration?.totalShots || 'N/A'}
+                    <div className="flex-1 space-y-2">
+                      <div className="font-medium ink-strong text-base">{asset.name}</div>
+                      <div className="text-xs ink-subtle">
+                        Seed: {asset.seedId.slice(0, 8)}... • Shots: {asset.metadata?.configuration?.totalShots || 'N/A'}
                       </div>
                       {asset.summary && (
-                        <div className="text-xs ink-subtle mt-2 p-2 bg-white/5 rounded">
+                        <div className="text-xs ink-subtle p-3 bg-white/10 rounded-lg">
                           {asset.summary}
                         </div>
                       )}
@@ -154,20 +160,23 @@ export const BatchStyleModal: React.FC<BatchStyleModalProps> = ({
           </div>
 
           {/* Master Image Selection */}
-          <div className="p-4 border-b border-white/20">
-            <h3 className="font-medium ink-strong mb-3 flex items-center gap-2">
-              <span className="inline-block w-6 h-6 bg-purple-500 text-white rounded-full text-center text-sm leading-6">2</span>
+          <div className="border border-purple-300/40 bg-purple-500/10 rounded-2xl p-6 space-y-4">
+            <h3 className="font-medium ink-strong flex items-center gap-3 text-base">
+              <span className="inline-flex w-8 h-8 items-center justify-center bg-purple-500 text-white rounded-full text-sm">2</span>
               Select Master Visual Style
             </h3>
-            <p className="text-xs ink-subtle mb-3">Choose one master image to provide the visual styling.</p>
+            <p className="text-sm ink-subtle">Choose one master image to provide the visual styling.</p>
             {masterImageAssets.length === 0 ? (
-              <p className="text-sm ink-subtle text-center py-4 bg-white/5 rounded-lg">
+              <p className="text-sm ink-subtle text-center py-6 bg-white/10 rounded-xl">
                 No master image assets available. Create master image assets first from visual assets.
               </p>
             ) : (
-              <div className="space-y-2">
+              <div className="max-h-72 overflow-y-auto custom-scrollbar space-y-3 pr-2">
                 {masterImageAssets.map(asset => (
-                  <label key={asset.id} className="flex items-start gap-3 p-3 cursor-pointer hover:bg-white/5 rounded-lg transition-colors border border-purple-200">
+                  <label
+                    key={asset.id}
+                    className="flex items-start gap-4 p-4 cursor-pointer hover:bg-white/10 rounded-xl transition-colors border border-purple-200/60"
+                  >
                     <input
                       type="radio"
                       name="masterImage"
@@ -175,14 +184,14 @@ export const BatchStyleModal: React.FC<BatchStyleModalProps> = ({
                       onChange={() => onSelectMasterImage(asset.id)}
                       className="mt-1"
                     />
-                    <div className="flex-1">
-                      <div className="font-medium ink-strong">{asset.name}</div>
-                      <div className="text-xs ink-subtle mt-1">
-                        Seed: {asset.seedId.slice(0, 8)}... | Type: {asset.type}
+                    <div className="flex-1 space-y-2">
+                      <div className="font-medium ink-strong text-base">{asset.name}</div>
+                      <div className="text-xs ink-subtle">
+                        Seed: {asset.seedId.slice(0, 8)}... • Type: {asset.type}
                       </div>
                       {asset.content && (
-                        <div className="text-xs ink-subtle mt-2 p-2 bg-white/5 rounded">
-                          {asset.content.substring(0, 150)}...
+                        <div className="text-xs ink-subtle p-3 bg-white/10 rounded-lg">
+                          {asset.content.substring(0, 180)}...
                         </div>
                       )}
                     </div>
@@ -194,41 +203,50 @@ export const BatchStyleModal: React.FC<BatchStyleModalProps> = ({
 
           {/* Summary Section */}
           {(selectedMultiShotAssets.length > 0 || selectedMasterImageAsset) && (
-            <div className="p-4 bg-purple-50/50">
-              <h3 className="font-medium ink-strong mb-2">Batch Style Application Summary</h3>
-              <div className="text-sm ink-subtle space-y-2">
-                <div>
-                  <strong>Multi-Shot Assets Selected:</strong> {selectedMultiShotAssets.length}
+            <div className="p-6 bg-purple-500/10 border border-purple-300/30 rounded-2xl space-y-4">
+              <h3 className="font-medium ink-strong">Batch Style Application Summary</h3>
+              <div className="grid gap-3 text-sm ink-subtle sm:grid-cols-2">
+                <div className="space-y-2">
+                  <strong className="block text-sm ink-strong">Multi-Shot Assets Selected</strong>
+                  <p className="text-xs">{selectedMultiShotAssets.length} plan{selectedMultiShotAssets.length === 1 ? '' : 's'}</p>
                   {selectedMultiShotAssets.length > 0 && (
-                    <ul className="mt-1 ml-4 space-y-1">
+                    <ul className="space-y-1 text-xs">
                       {selectedMultiShotAssets.map(asset => {
-                        const totalShots = asset.metadata?.configuration?.totalShots || 0;
+                        const totalShots = asset.metadata?.configuration?.totalShots || asset.shotCount || 0;
                         return (
-                          <li key={asset.id} className="text-xs">• {asset.name} ({totalShots} shots)</li>
+                          <li key={asset.id}>• {asset.name} ({totalShots} shots)</li>
                         );
                       })}
                     </ul>
                   )}
                 </div>
-                <div>
-                  <strong>Master Visual Style:</strong> {selectedMasterImageAsset ? selectedMasterImageAsset.name : 'None selected'}
+                <div className="space-y-2">
+                  <strong className="block text-sm ink-strong">Master Visual Style</strong>
+                  <p className="text-xs">
+                    {selectedMasterImageAsset ? selectedMasterImageAsset.name : 'No master style selected yet'}
+                  </p>
                   {selectedMasterImageAsset && (
-                    <p className="text-xs mt-1 p-2 bg-white/20 rounded">
-                      {selectedMasterImageAsset.content?.substring(0, 100)}...
+                    <p className="text-xs p-3 bg-white/10 rounded-lg">
+                      {selectedMasterImageAsset.content?.substring(0, 160)}...
                     </p>
                   )}
-                </div>
-                {selectedMultiShotAssets.length > 0 && selectedMasterImageAsset && (
-                  <div className="mt-3 p-2 bg-white/30 rounded text-xs">
-                    <strong>Result:</strong> The visual style from "{selectedMasterImageAsset.name}" will be applied to all shots in the {selectedMultiShotAssets.length} selected multi-shot asset(s), creating styled final outputs ready for video generation.
+                  <div className="text-xs">
+                    <strong>Total Shots Styled:</strong>{' '}
+                    {selectedMultiShotAssets.reduce((total, asset) =>
+                      total + (asset.metadata?.configuration?.totalShots || asset.shotCount || 0), 0)}
                   </div>
-                )}
+                </div>
               </div>
+              {selectedMultiShotAssets.length > 0 && selectedMasterImageAsset && (
+                <div className="p-3 bg-white/20 rounded-xl text-xs">
+                  <strong>Result:</strong> The visual style from "{selectedMasterImageAsset.name}" will be applied to all shots in the {selectedMultiShotAssets.length} selected multi-shot asset{selectedMultiShotAssets.length === 1 ? '' : 's'}, creating styled batches ready for downstream workflows.
+                </div>
+              )}
             </div>
           )}
         </div>
 
-        <div className="glass-modal__actions">
+        <div className="glass-modal__actions px-8 pb-8">
           <button
             ref={confirmButtonRef}
             className="modal-button modal-button--primary"

--- a/loop/src/components/MultiShotCreationModal.tsx
+++ b/loop/src/components/MultiShotCreationModal.tsx
@@ -7,7 +7,13 @@ interface MultiShotModalProps {
   assets: Asset[];
   selectedAssets: string[];
   onToggleAsset: (assetId: string) => void;
-  onConfirm: (numberOfShots: number, shotType: string, shotDetails?: any, structuredData?: StructuredInputData, individualShots?: IndividualShot[]) => void;
+  onConfirm: (
+    numberOfShots: number,
+    shotType: string,
+    shotDetails?: any,
+    structuredData?: StructuredInputData,
+    individualShots?: IndividualShot[]
+  ) => boolean | void;
   onCancel: () => void;
 }
 
@@ -180,7 +186,7 @@ export const MultiShotCreationModal: React.FC<MultiShotModalProps> = ({
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
-        style={{ maxWidth: '700px', maxHeight: '85vh' }}
+        style={{ maxWidth: '95vw', width: '1400px', maxHeight: '95vh', minHeight: '720px' }}
       >
         <div className="glass-modal__header">
           <h2 id={titleId} className="glass-modal__title ink-strong">Create Multi-Shot Asset</h2>
@@ -188,35 +194,40 @@ export const MultiShotCreationModal: React.FC<MultiShotModalProps> = ({
         <p id={descriptionId} className="glass-modal__description">
           Create comprehensive multi-shot assets with detailed configuration and per-shot customization.
         </p>
+
+        <div
+          className="flex-1 overflow-y-auto custom-scrollbar px-8 py-6 space-y-8"
+          style={{ maxHeight: 'calc(95vh - 220px)' }}
+        >
         
         {/* Tab Navigation */}
-        <div className="flex border-b border-white/20">
+        <div className="flex flex-wrap gap-3">
           <button
             onClick={() => setActiveTab('basic')}
-            className={`px-4 py-3 text-sm font-medium transition-colors ${
-              activeTab === 'basic' 
-                ? 'border-b-2 border-blue-500 text-blue-600 ink-strong' 
-                : 'text-gray-400 hover:text-gray-200'
+            className={`px-4 py-2.5 text-sm font-semibold rounded-full transition-colors ${
+              activeTab === 'basic'
+                ? 'bg-blue-500/20 text-blue-100 border border-blue-400/40'
+                : 'text-gray-400 border border-transparent hover:text-gray-200 hover:border-white/20'
             }`}
           >
             📋 Basic Setup
           </button>
           <button
             onClick={() => setActiveTab('structured')}
-            className={`px-4 py-3 text-sm font-medium transition-colors ${
-              activeTab === 'structured' 
-                ? 'border-b-2 border-blue-500 text-blue-600 ink-strong' 
-                : 'text-gray-400 hover:text-gray-200'
+            className={`px-4 py-2.5 text-sm font-semibold rounded-full transition-colors ${
+              activeTab === 'structured'
+                ? 'bg-blue-500/20 text-blue-100 border border-blue-400/40'
+                : 'text-gray-400 border border-transparent hover:text-gray-200 hover:border-white/20'
             }`}
           >
             🎬 Structured Data
           </button>
           <button
             onClick={() => setActiveTab('individual')}
-            className={`px-4 py-3 text-sm font-medium transition-colors ${
-              activeTab === 'individual' 
-                ? 'border-b-2 border-blue-500 text-blue-600 ink-strong' 
-                : 'text-gray-400 hover:text-gray-200'
+            className={`px-4 py-2.5 text-sm font-semibold rounded-full transition-colors ${
+              activeTab === 'individual'
+                ? 'bg-blue-500/20 text-blue-100 border border-blue-400/40'
+                : 'text-gray-400 border border-transparent hover:text-gray-200 hover:border-white/20'
             }`}
           >
             🎯 Per-Shot Config
@@ -224,10 +235,12 @@ export const MultiShotCreationModal: React.FC<MultiShotModalProps> = ({
         </div>
 
         {/* Tab Content */}
-        <div className="p-4 space-y-6 max-h-96 overflow-y-auto custom-scrollbar" style={{ borderBottom: '1px solid hsl(var(--border))' }}>
+        <div
+          className="p-6 space-y-6 max-h-[28rem] overflow-y-auto custom-scrollbar bg-white/5 border border-white/10 rounded-2xl"
+        >
           {/* Basic Setup Tab */}
           {activeTab === 'basic' && (
-            <div className="space-y-4">
+            <div className="space-y-6">
           <div>
             <label className="block text-sm font-medium ink-strong mb-2">
               Number of Shots per Scene
@@ -349,7 +362,7 @@ export const MultiShotCreationModal: React.FC<MultiShotModalProps> = ({
 
           {/* Structured Data Tab */}
           {activeTab === 'structured' && (
-            <div className="space-y-4">
+            <div className="space-y-6">
               <p className="text-sm ink-subtle mb-4">
                 Create comprehensive structured data that will be included in all generated shots for better context and consistency.
               </p>
@@ -501,7 +514,7 @@ export const MultiShotCreationModal: React.FC<MultiShotModalProps> = ({
 
           {/* Individual Shot Configuration Tab */}
           {activeTab === 'individual' && (
-            <div className="space-y-4">
+            <div className="space-y-6">
               <div className="flex items-center justify-between">
                 <p className="text-sm ink-subtle">
                   Configure each shot individually with specific parameters.
@@ -637,55 +650,97 @@ export const MultiShotCreationModal: React.FC<MultiShotModalProps> = ({
           )}
         </div>
 
-        {/* Asset Selection - moved outside of tab content */}
-        <div className="border-t border-white/20">
-          <div className="max-h-64 overflow-y-auto custom-scrollbar p-4 space-y-2">
-          <h3 className="font-medium ink-strong mb-2">Select Master Story Assets</h3>
-          {masterStoryAssets.length === 0 ? (
-            <p className="text-sm ink-subtle text-center py-4">No master story assets available. Create master story assets first.</p>
-          ) : (
-            masterStoryAssets.map(asset => (
-              <label key={asset.id} className="flex items-start gap-3 p-3 cursor-pointer hover:bg-white/5 rounded-lg transition-colors border border-white/10">
-                <input
-                  type="checkbox"
-                  checked={selectedAssets.includes(asset.id)}
-                  onChange={() => onToggleAsset(asset.id)}
-                  className="mt-1"
-                />
-                <div className="flex-1">
-                  <div className="font-medium ink-strong">{asset.name}</div>
-                  <div className="text-xs ink-subtle mt-1">
-                    Seed: {asset.seedId.slice(0, 8)}...
-                  </div>
-                  {asset.content && (
-                    <div className="text-xs ink-subtle mt-2 p-2 bg-white/5 rounded">
-                      {asset.content.substring(0, 150)}...
-                    </div>
-                  )}
-                </div>
-              </label>
-            ))
+        <div className="p-6 bg-white/5 border border-white/10 rounded-2xl space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold ink-strong">Generation Overview</h3>
+            <span className="text-xs ink-subtle">{selectedAssets.length} scene{selectedAssets.length === 1 ? '' : 's'} selected</span>
+          </div>
+          <div className="grid gap-4 text-sm ink-subtle sm:grid-cols-2">
+            <div className="space-y-1">
+              <p><strong>Total shots planned:</strong> {selectedAssets.length * numberOfShots}</p>
+              <p><strong>Shot emphasis:</strong> {shotType.replace('_', ' ')}</p>
+              <p><strong>Duration:</strong> {shotDetails.duration}</p>
+            </div>
+            <div className="space-y-1">
+              <p><strong>Camera movement:</strong> {shotDetails.cameraMovement.replace('_', ' ')}</p>
+              <p><strong>Lighting:</strong> {shotDetails.lightingStyle.replace('_', ' ')}</p>
+              {structuredData.sceneDescription && (
+                <p>
+                  <strong>Scene focus:</strong> {structuredData.sceneDescription.substring(0, 120)}
+                  {structuredData.sceneDescription.length > 120 ? '...' : ''}
+                </p>
+              )}
+            </div>
+          </div>
+          {enablePerShotConfig && individualShots.length > 0 && (
+            <div className="text-xs ink-subtle p-3 bg-white/10 rounded-lg">
+              <strong>Per-shot configuration enabled.</strong> Customize each shot below.
+            </div>
           )}
+        </div>
+
+        {/* Asset Selection - moved outside of tab content */}
+        <div className="border border-white/10 rounded-2xl p-6 bg-white/5">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-medium ink-strong">Select Master Story Assets</h3>
+            <span className="text-xs ink-subtle">{selectedAssets.length} selected</span>
+          </div>
+          <div className="max-h-72 overflow-y-auto custom-scrollbar space-y-3 pr-2">
+            {masterStoryAssets.length === 0 ? (
+              <p className="text-sm ink-subtle text-center py-6 bg-white/5 rounded-xl">
+                No master story assets available. Create master story assets first.
+              </p>
+            ) : (
+              masterStoryAssets.map(asset => (
+                <label
+                  key={asset.id}
+                  className="flex items-start gap-3 p-4 cursor-pointer hover:bg-white/10 rounded-xl transition-colors border border-white/10"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedAssets.includes(asset.id)}
+                    onChange={() => onToggleAsset(asset.id)}
+                    className="mt-1"
+                  />
+                  <div className="flex-1">
+                    <div className="font-medium ink-strong">{asset.name}</div>
+                    <div className="text-xs ink-subtle mt-1">
+                      Seed: {asset.seedId.slice(0, 8)}...
+                    </div>
+                    {asset.content && (
+                      <div className="text-xs ink-subtle mt-2 p-3 bg-white/5 rounded-lg">
+                        {asset.content.substring(0, 180)}...
+                      </div>
+                    )}
+                  </div>
+                </label>
+              ))
+            )}
           </div>
         </div>
 
         {/* Summary Section */}
         {selectedMasterStories.length > 0 && (
-          <div className="p-4 bg-blue-50/50 border-t border-white/20">
-            <h3 className="font-medium ink-strong mb-2">Multi-Shot Configuration Summary</h3>
-            <div className="text-sm ink-subtle space-y-1">
+          <div className="p-6 bg-blue-500/10 border border-blue-300/30 rounded-2xl space-y-3">
+            <h3 className="font-medium ink-strong">Multi-Shot Configuration Summary</h3>
+            <div className="grid gap-2 sm:grid-cols-2 text-sm ink-subtle">
               <p>• Selected Scenes: {selectedMasterStories.length}</p>
               <p>• Shots per Scene: {numberOfShots}</p>
               <p>• Shot Type: {shotType.replace('_', ' ')}</p>
               <p>• Duration: {shotDetails.duration}</p>
               <p>• Camera Movement: {shotDetails.cameraMovement.replace('_', ' ')}</p>
               <p>• Lighting: {shotDetails.lightingStyle.replace('_', ' ')}</p>
-              {shotDetails.shotDescription && <p>• Custom Notes: {shotDetails.shotDescription.substring(0, 50)}{shotDetails.shotDescription.length > 50 ? '...' : ''}</p>}
+              {shotDetails.shotDescription && (
+                <p className="sm:col-span-2">
+                  • Custom Notes: {shotDetails.shotDescription.substring(0, 160)}
+                  {shotDetails.shotDescription.length > 160 ? '...' : ''}
+                </p>
+              )}
               <p>• Total Shots to Generate: {selectedMasterStories.length * numberOfShots}</p>
             </div>
-            <div className="mt-3 p-3 bg-white/20 rounded text-xs ink-subtle">
-              <strong>Selected Stories:</strong>
-              <ul className="mt-1 space-y-1">
+            <div className="p-4 bg-white/10 rounded-xl text-xs ink-subtle space-y-1">
+              <strong className="block text-sm ink-strong">Selected Stories:</strong>
+              <ul className="space-y-1">
                 {selectedMasterStories.map(asset => (
                   <li key={asset.id}>• {asset.name}</li>
                 ))}
@@ -694,7 +749,9 @@ export const MultiShotCreationModal: React.FC<MultiShotModalProps> = ({
           </div>
         )}
 
-        <div className="glass-modal__actions">
+        </div>
+
+        <div className="glass-modal__actions px-8 pb-8">
           <button
             ref={confirmButtonRef}
             className="modal-button modal-button--primary"

--- a/loop/src/components/Timeline.tsx
+++ b/loop/src/components/Timeline.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import type { Asset, Project, TimelineBlock } from '../types';
+import type { Asset, Project, TimelineBlock, StructuredInputData, IndividualShot, ShotDetails } from '../types';
 import { ASSET_TEMPLATES } from '../constants';
 import { MagicWandIcon, PlusIcon, SparklesIcon } from './IconComponents';
+import { MultiShotCreationModal } from './MultiShotCreationModal';
+import { BatchStyleModal } from './BatchStyleModal';
 
 // @ts-ignore
 export const Timeline = ({
@@ -17,9 +19,16 @@ export const Timeline = ({
   onWeightingToggle,
   styleRigidity,
   onStyleRigidityChange,
-  setIsOutputModalOpen,
-  onOpenMultiShotModal,
-  onOpenBatchStyleModal
+  selectedStoryAssets,
+  onToggleStoryAsset,
+  onConfirmMultiShot,
+  onCancelMultiShot,
+  selectedMultiShots,
+  selectedMasterImage,
+  onToggleMultiShot,
+  onSelectMasterImage,
+  onConfirmBatchStyle,
+  onCancelBatchStyle
 }: {
   project: Project;
   selectedAssetId: string | null;
@@ -33,9 +42,22 @@ export const Timeline = ({
   onWeightingToggle: (enabled: boolean) => void;
   styleRigidity: number;
   onStyleRigidityChange: (value: number) => void;
-  setIsOutputModalOpen: (open: boolean) => void;
-  onOpenMultiShotModal: () => void;
-  onOpenBatchStyleModal: () => void;
+  selectedStoryAssets: string[];
+  onToggleStoryAsset: (assetId: string) => void;
+  onConfirmMultiShot: (
+    numberOfShots: number,
+    shotType: string,
+    shotDetails?: ShotDetails,
+    structuredData?: StructuredInputData,
+    individualShots?: IndividualShot[]
+  ) => boolean | void;
+  onCancelMultiShot: () => void;
+  selectedMultiShots: string[];
+  selectedMasterImage: string | null;
+  onToggleMultiShot: (assetId: string) => void;
+  onSelectMasterImage: (assetId: string) => void;
+  onConfirmBatchStyle: () => boolean | void;
+  onCancelBatchStyle: () => void;
   onGenerateDirectorAdvice?: () => void;
   onAcceptSuggestion?: (suggestionId: string) => void;
 }) => {
@@ -64,6 +86,9 @@ export const Timeline = ({
       return acc;
     }, {} as Record<string, Asset[]>);
   }, [project.assets]);
+
+  const [isMultiShotModalOpen, setIsMultiShotModalOpen] = React.useState(false);
+  const [isBatchStyleModalOpen, setIsBatchStyleModalOpen] = React.useState(false);
 
 const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?: Record<string, number>) => {
     const asset = project.assets.find(a => a.id === block.assetId);
@@ -302,7 +327,7 @@ const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?:
           <div className="group inline-flex items-center gap-2">
             <button
               type="button"
-              onClick={onOpenMultiShotModal}
+              onClick={() => setIsMultiShotModalOpen(true)}
               className="timeline-action px-6 py-3 text-base font-semibold flex items-center gap-2 shadow-lg transform hover:scale-105 transition-all duration-200"
               style={{
                 background: 'linear-gradient(145deg, #E6E6FA, #D1D1F0)',
@@ -317,6 +342,24 @@ const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?:
             </button>
           </div>
         </div>
+
+        <MultiShotCreationModal
+          isOpen={isMultiShotModalOpen}
+          assets={project.assets}
+          selectedAssets={selectedStoryAssets}
+          onToggleAsset={onToggleStoryAsset}
+          onConfirm={(numberOfShots, shotType, shotDetails, structuredData, individualShots) => {
+            const result = onConfirmMultiShot(numberOfShots, shotType, shotDetails, structuredData, individualShots);
+            if (result !== false) {
+              setIsMultiShotModalOpen(false);
+            }
+            return result;
+          }}
+          onCancel={() => {
+            setIsMultiShotModalOpen(false);
+            onCancelMultiShot();
+          }}
+        />
 
         <div className="space-y-10 px-1">
           <div>
@@ -423,7 +466,7 @@ const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?:
           <div className="group inline-flex items-center gap-2">
             <button
               type="button"
-              onClick={onOpenBatchStyleModal}
+              onClick={() => setIsBatchStyleModalOpen(true)}
               className="timeline-action px-6 py-3 text-base font-semibold flex items-center gap-2 shadow-lg transform hover:scale-105 transition-all duration-200"
               style={{
                 background: 'linear-gradient(145deg, #98FB98, #7AE67A)',
@@ -438,6 +481,26 @@ const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?:
             </button>
           </div>
         </div>
+
+        <BatchStyleModal
+          isOpen={isBatchStyleModalOpen}
+          assets={project.assets}
+          selectedMultiShots={selectedMultiShots}
+          selectedMasterImage={selectedMasterImage}
+          onToggleMultiShot={onToggleMultiShot}
+          onSelectMasterImage={onSelectMasterImage}
+          onConfirm={() => {
+            const result = onConfirmBatchStyle();
+            if (result !== false) {
+              setIsBatchStyleModalOpen(false);
+            }
+            return result;
+          }}
+          onCancel={() => {
+            setIsBatchStyleModalOpen(false);
+            onCancelBatchStyle();
+          }}
+        />
 
         <div className="space-y-10 px-1">
           <div>


### PR DESCRIPTION
## Summary
- render the multi-shot and batch style creation modals directly inside the timeline with local open state so they stay attached to their action buttons
- remove redundant modal state in the workspace component and forward the selection/confirm handlers used by the timeline
- expand the multi-shot and batch style modal layouts to match the wider output modal styling with generous padding and updated summaries

## Testing
- Not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68e607ca0e948326a1006656162c8705