### PR TITLE
Handle missing seed IDs in batch modals

### DIFF
--- a/loop/src/components/BatchStyleModal.tsx
+++ b/loop/src/components/BatchStyleModal.tsx
@@ -145,7 +145,7 @@ export const BatchStyleModal: React.FC<BatchStyleModalProps> = ({
                     <div className="flex-1 space-y-2">
                       <div className="font-medium ink-strong text-base">{asset.name}</div>
                       <div className="text-xs ink-subtle">
-                        Seed: {asset.seedId.slice(0, 8)}... • Shots: {asset.metadata?.configuration?.totalShots || 'N/A'}
+                        Seed: {asset.seedId ? `${asset.seedId.slice(0, 8)}...` : 'Not provided'} • Shots: {asset.metadata?.configuration?.totalShots || 'N/A'}
                       </div>
                       {asset.summary && (
                         <div className="text-xs ink-subtle p-3 bg-white/10 rounded-lg">
@@ -187,7 +187,7 @@ export const BatchStyleModal: React.FC<BatchStyleModalProps> = ({
                     <div className="flex-1 space-y-2">
                       <div className="font-medium ink-strong text-base">{asset.name}</div>
                       <div className="text-xs ink-subtle">
-                        Seed: {asset.seedId.slice(0, 8)}... • Type: {asset.type}
+                        Seed: {asset.seedId ? `${asset.seedId.slice(0, 8)}...` : 'Not provided'} • Type: {asset.type}
                       </div>
                       {asset.content && (
                         <div className="text-xs ink-subtle p-3 bg-white/10 rounded-lg">

--- a/loop/src/components/MultiShotCreationModal.tsx
+++ b/loop/src/components/MultiShotCreationModal.tsx
@@ -705,7 +705,7 @@ export const MultiShotCreationModal: React.FC<MultiShotModalProps> = ({
                   <div className="flex-1">
                     <div className="font-medium ink-strong">{asset.name}</div>
                     <div className="text-xs ink-subtle mt-1">
-                      Seed: {asset.seedId.slice(0, 8)}...
+                      Seed: {asset.seedId ? `${asset.seedId.slice(0, 8)}...` : 'Not provided'}
                     </div>
                     {asset.content && (
                       <div className="text-xs ink-subtle mt-2 p-3 bg-white/5 rounded-lg">


### PR DESCRIPTION
## Summary
- guard modal seed readouts against missing seed IDs in the multi-shot selection list
- apply the same fallback copy to batch style modal seed displays for multi-shot and master image assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6121ec19483268402a8c90c67a134