### PR TITLE
Center style rigidity slider highlight

### DIFF
--- a/loop/src/components/Timeline.tsx
+++ b/loop/src/components/Timeline.tsx
@@ -60,6 +60,18 @@ export const Timeline = ({
   onAcceptSuggestion?: (suggestionId: string) => void;
 }) => {
 
+  const sliderVariables = React.useMemo(() => {
+    const center = 50;
+    const offset = Math.abs(styleRigidity - center);
+    const start = Math.max(0, center - offset);
+    const end = Math.min(100, center + offset);
+
+    return {
+      '--slider-start': `${start}%`,
+      '--slider-end': `${end}%`
+    } as React.CSSProperties;
+  }, [styleRigidity]);
+
   const handleDrop = (e: React.DragEvent<HTMLDivElement>, folder?: string) => {
     e.preventDefault();
     const templateType = e.dataTransfer.getData('text/plain');
@@ -300,10 +312,8 @@ const renderAssetBlock = (block: TimelineBlock, index: number, assetTypeCounts?:
                         max="100"
                         value={styleRigidity}
                         onChange={(e) => onStyleRigidityChange(parseInt(e.target.value, 10))}
-                        className="w-full h-1 bg-white/30 rounded-full appearance-none cursor-pointer"
-                        style={{
-                          background: `linear-gradient(to right, hsl(var(--primary)) 0%, hsl(var(--primary)) ${styleRigidity}%, rgba(255,255,255,0.3) ${styleRigidity}%, rgba(255,255,255,0.3) 100%)`
-                        }}
+                        className="timeline-style-slider"
+                        style={sliderVariables}
                         disabled={!isWeightingEnabled}
                       />
                       <div className="pointer-events-none absolute inset-0 flex items-center justify-center">

--- a/loop/src/index.css
+++ b/loop/src/index.css
@@ -1037,6 +1037,98 @@
   filter: brightness(1.05) saturate(1.1);
 }
 
+.timeline-style-slider {
+  --slider-track-color: rgba(255, 255, 255, 0.28);
+  --slider-highlight: hsl(var(--primary));
+  --slider-start: 50%;
+  --slider-end: 50%;
+  appearance: none;
+  width: 100%;
+  height: 0.25rem;
+  border-radius: 9999px;
+  background: linear-gradient(
+    90deg,
+    var(--slider-track-color) 0%,
+    var(--slider-track-color) var(--slider-start),
+    var(--slider-highlight) var(--slider-start),
+    var(--slider-highlight) var(--slider-end),
+    var(--slider-track-color) var(--slider-end),
+    var(--slider-track-color) 100%
+  );
+  transition: background 0.2s ease;
+  cursor: pointer;
+}
+
+.timeline-style-slider:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.timeline-style-slider::-webkit-slider-runnable-track {
+  height: 0.25rem;
+  border-radius: 9999px;
+  background: linear-gradient(
+    90deg,
+    var(--slider-track-color) 0%,
+    var(--slider-track-color) var(--slider-start),
+    var(--slider-highlight) var(--slider-start),
+    var(--slider-highlight) var(--slider-end),
+    var(--slider-track-color) var(--slider-end),
+    var(--slider-track-color) 100%
+  );
+}
+
+.timeline-style-slider::-moz-range-track {
+  height: 0.25rem;
+  border-radius: 9999px;
+  background: linear-gradient(
+    90deg,
+    var(--slider-track-color) 0%,
+    var(--slider-track-color) var(--slider-start),
+    var(--slider-highlight) var(--slider-start),
+    var(--slider-highlight) var(--slider-end),
+    var(--slider-track-color) var(--slider-end),
+    var(--slider-track-color) 100%
+  );
+}
+
+.timeline-style-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.18);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  margin-top: calc(-0.9rem / 2 + 0.125rem);
+}
+
+.timeline-style-slider:active::-webkit-slider-thumb {
+  transform: scale(1.05);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.2);
+}
+
+.timeline-style-slider::-moz-range-thumb {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.18);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.timeline-style-slider:active::-moz-range-thumb {
+  transform: scale(1.05);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.2);
+}
+
+.timeline-style-slider::-moz-focus-outer {
+  border: 0;
+}
+
 .glass-hover {
   transition: all 0.4s cubic-bezier(0.23, 1, 0.32, 1);
   backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- compute center-origin slider variables in the timeline to keep the highlight symmetric around the midpoint
- add a reusable slider track style that renders the pink segment consistently across browsers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6122388448326b73be3baad9a786e