### PR TITLE
Prevent duplicate logger handler registrations

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -1,11 +1,15 @@
 import logging  
 
-def setup_logger():  
-    """Set up the logger for the application."""  
-    logger = logging.getLogger('flask-api-service')  
-    logger.setLevel(logging.INFO)  
-    handler = logging.StreamHandler()  
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')  
-    handler.setFormatter(formatter)  
-    logger.addHandler(handler)  
+def setup_logger():
+    """Set up and return the configured application logger."""
+
+    logger = logging.getLogger('flask-api-service')
+    logger.setLevel(logging.INFO)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
     return logger


### PR DESCRIPTION
## Summary
- ensure the Flask logger only attaches a stream handler once
- keep the existing logging level and formatting while reusing the configured logger

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e65022d8f48326a04dc9fb7b4ca9ea