### PR TITLE
Fix seed normalization build failure

### DIFF
--- a/loop/src/components/__tests__/TimelineModals.test.tsx
+++ b/loop/src/components/__tests__/TimelineModals.test.tsx
@@ -1,9 +1,19 @@
+import { vi } from 'vitest';
+
+vi.mock('../../services/config', () => ({
+  apiConfig: {
+    getConfigs: vi.fn(() => []),
+    addConfig: vi.fn(),
+    updateConfigByName: vi.fn(),
+    removeConfigByName: vi.fn(),
+  },
+}));
+
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Workspace from '../../components/Workspace';
 import type { Project, Asset } from '../../types';
-import { vi } from 'vitest';
 import { useProject } from '../../hooks/useProject';
 
 const MultiShotModalStub: React.FC<any> = ({ isOpen, onCancel }) => {
@@ -44,7 +54,7 @@ describe('timeline modal triggers', () => {
       summary: 'A hero begins the journey',
       isMaster: true,
       lineage: [],
-      metadata: {}
+      metadata: {},
     },
     {
       id: 'multi-shot-1',
@@ -56,9 +66,9 @@ describe('timeline modal triggers', () => {
       createdAt: new Date('2024-01-02T00:00:00Z'),
       summary: 'Planned multi shot sequence',
       metadata: {
-        configuration: { totalShots: 3 }
+        configuration: { totalShots: 3 },
       },
-      lineage: []
+      lineage: [],
     },
     {
       id: 'image-1',
@@ -71,8 +81,8 @@ describe('timeline modal triggers', () => {
       summary: 'Primary visual tone',
       isMaster: true,
       lineage: [],
-      metadata: {}
-    }
+      metadata: {},
+    },
   ];
 
   const baseProject: Project = {
@@ -84,21 +94,21 @@ describe('timeline modal triggers', () => {
       folders: {
         story: [],
         image: [],
-        text_to_video: []
-      }
+        text_to_video: [],
+      },
     },
     secondaryTimeline: {
       masterAssets: [baseAssets[0]],
       shotLists: [],
-      appliedStyles: {}
+      appliedStyles: {},
     },
     thirdTimeline: {
       styledShots: [],
       videoPrompts: [],
-      batchStyleAssets: []
+      batchStyleAssets: [],
     },
     createdAt: new Date('2024-01-01T00:00:00Z'),
-    updatedAt: new Date('2024-01-04T00:00:00Z')
+    updatedAt: new Date('2024-01-04T00:00:00Z'),
   };
 
   const defaultHandlers = {
@@ -120,10 +130,12 @@ describe('timeline modal triggers', () => {
     onStyleRigidityChange: vi.fn(),
     onWeightingToggle: vi.fn(),
     onGenerate: vi.fn(),
-    onGenerateOutput: vi.fn()
+    onGenerateOutput: vi.fn(),
   } as const;
 
-  const renderWorkspace = (overrides: Partial<React.ComponentProps<typeof Workspace>> = {}) => {
+  const renderWorkspace = (
+    overrides: Partial<React.ComponentProps<typeof Workspace>> = {},
+  ) => {
     const props: React.ComponentProps<typeof Workspace> = {
       appLabel: 'Loop',
       project: baseProject,
@@ -157,7 +169,7 @@ describe('timeline modal triggers', () => {
       isGenerating: false,
       onGenerate: defaultHandlers.onGenerate,
       onGenerateOutput: defaultHandlers.onGenerateOutput,
-      ...overrides
+      ...overrides,
     };
 
     return render(<Workspace {...props} />);
@@ -167,18 +179,28 @@ describe('timeline modal triggers', () => {
     const user = userEvent.setup();
     renderWorkspace({ activeTimeline: 'secondary' });
 
-    await user.click(screen.getByRole('button', { name: /create multi-shot/i }));
+    await user.click(
+      screen.getByRole('button', { name: /create multi-shot/i }),
+    );
 
-    expect(await screen.findByRole('dialog', { name: /create multi-shot asset/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('dialog', { name: /create multi-shot asset/i }),
+    ).toBeInTheDocument();
   });
 
   it('opens the batch style modal from the batch style timeline', async () => {
     const user = userEvent.setup();
     renderWorkspace({ activeTimeline: 'third' });
 
-    await user.click(screen.getByRole('button', { name: /create batch style/i }));
+    await user.click(
+      screen.getByRole('button', { name: /create batch style/i }),
+    );
 
-    expect(await screen.findByRole('dialog', { name: /create batch style application/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('dialog', {
+        name: /create batch style application/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   it('normalizes missing seed IDs before rendering timeline modals', async () => {
@@ -190,7 +212,11 @@ describe('timeline modal triggers', () => {
 
     const projectWithMissingSeeds: Project = {
       ...baseProject,
-      assets: [masterStoryWithoutSeed, multiShotWithoutSeed, masterImageWithoutSeed],
+      assets: [
+        masterStoryWithoutSeed,
+        multiShotWithoutSeed,
+        masterImageWithoutSeed,
+      ],
       secondaryTimeline: {
         masterAssets: [masterImageWithoutSeed],
         shotLists: [
@@ -198,16 +224,16 @@ describe('timeline modal triggers', () => {
             id: 'shotlist-1',
             masterAssetId: masterStoryWithoutSeed.id,
             shots: [multiShotWithoutSeed],
-            createdAt: new Date('2024-01-05T00:00:00Z')
-          }
+            createdAt: new Date('2024-01-05T00:00:00Z'),
+          },
         ],
-        appliedStyles: {}
+        appliedStyles: {},
       },
       thirdTimeline: {
         styledShots: [multiShotWithoutSeed],
         videoPrompts: [],
-        batchStyleAssets: [masterImageWithoutSeed]
-      }
+        batchStyleAssets: [masterImageWithoutSeed],
+      },
     };
 
     const Harness: React.FC = () => {
@@ -236,12 +262,15 @@ describe('timeline modal triggers', () => {
         setActiveTimeline,
         isGenerating,
         handleGenerate,
-        handleGenerateOutput
+        handleGenerateOutput,
       } = useProject(projectWithMissingSeeds);
 
-      const [tagWeights, setTagWeights] = React.useState<Record<string, number>>({});
+      const [tagWeights, setTagWeights] = React.useState<
+        Record<string, number>
+      >({});
       const [styleRigidity, setStyleRigidity] = React.useState<number>(50);
-      const [isWeightingEnabled, setIsWeightingEnabled] = React.useState<boolean>(false);
+      const [isWeightingEnabled, setIsWeightingEnabled] =
+        React.useState<boolean>(false);
 
       return (
         <Workspace
@@ -269,7 +298,9 @@ describe('timeline modal triggers', () => {
           tagWeights={tagWeights}
           styleRigidity={styleRigidity}
           isWeightingEnabled={isWeightingEnabled}
-          onTagWeightChange={(tagId, weight) => setTagWeights(prev => ({ ...prev, [tagId]: weight }))}
+          onTagWeightChange={(tagId, weight) =>
+            setTagWeights((prev) => ({ ...prev, [tagId]: weight }))
+          }
           onStyleRigidityChange={setStyleRigidity}
           onWeightingToggle={setIsWeightingEnabled}
           activeTimeline={activeTimeline}
@@ -283,15 +314,112 @@ describe('timeline modal triggers', () => {
 
     render(<Harness />);
 
-    await user.click(await screen.findByRole('button', { name: /multi-shot/i }));
-    await user.click(await screen.findByRole('button', { name: /create multi-shot/i }));
-    expect(await screen.findByRole('dialog', { name: /create multi-shot asset/i })).toBeInTheDocument();
+    await user.click(
+      await screen.findByRole('button', { name: /multi-shot/i }),
+    );
+    await user.click(
+      await screen.findByRole('button', { name: /create multi-shot/i }),
+    );
+    expect(
+      await screen.findByRole('dialog', { name: /create multi-shot asset/i }),
+    ).toBeInTheDocument();
 
-    await user.click(await screen.findByRole('button', { name: /close multi-shot modal/i }));
+    await user.click(
+      await screen.findByRole('button', { name: /close multi-shot modal/i }),
+    );
 
-    await user.click(await screen.findByRole('button', { name: /batch style/i }));
-    await user.click(await screen.findByRole('button', { name: /create batch style/i }));
-    expect(await screen.findByRole('dialog', { name: /create batch style application/i })).toBeInTheDocument();
-    await user.click(await screen.findByRole('button', { name: /close batch style modal/i }));
+    await user.click(
+      await screen.findByRole('button', { name: /batch style/i }),
+    );
+    await user.click(
+      await screen.findByRole('button', { name: /create batch style/i }),
+    );
+    expect(
+      await screen.findByRole('dialog', {
+        name: /create batch style application/i,
+      }),
+    ).toBeInTheDocument();
+    await user.click(
+      await screen.findByRole('button', { name: /close batch style modal/i }),
+    );
+  });
+
+  it('maintains canonical seed IDs across all timelines for shared assets', async () => {
+    const sharedAssetBase: Asset = {
+      id: 'shared-asset',
+      seedId: '',
+      type: 'master_image',
+      name: 'Shared Asset',
+      content: 'Shared content',
+      tags: ['shared'],
+      createdAt: new Date('2024-02-01T00:00:00Z'),
+      summary: 'A shared asset',
+      isMaster: true,
+      lineage: [],
+      metadata: {},
+    };
+
+    const projectWithSharedAssets: Project = {
+      ...baseProject,
+      assets: [{ ...sharedAssetBase }, { ...baseAssets[1] }],
+      secondaryTimeline: {
+        masterAssets: [{ ...sharedAssetBase, seedId: '' }],
+        shotLists: [
+          {
+            id: 'shotlist-canonical',
+            masterAssetId: sharedAssetBase.id,
+            shots: [{ ...sharedAssetBase, seedId: '' }],
+            createdAt: new Date('2024-02-10T00:00:00Z'),
+          },
+        ],
+        appliedStyles: {},
+      },
+      thirdTimeline: {
+        styledShots: [{ ...sharedAssetBase, seedId: 'styled-seed' }],
+        videoPrompts: [],
+        batchStyleAssets: [{ ...sharedAssetBase, seedId: '' }],
+      },
+    };
+
+    const onProjectNormalized = vi.fn();
+
+    const CaptureProject: React.FC<{ initialProject: Project }> = ({
+      initialProject,
+    }) => {
+      const { project } = useProject(initialProject);
+
+      React.useEffect(() => {
+        onProjectNormalized(project);
+      }, [onProjectNormalized, project]);
+
+      return null;
+    };
+
+    render(<CaptureProject initialProject={projectWithSharedAssets} />);
+
+    await waitFor(() => {
+      expect(onProjectNormalized).toHaveBeenCalled();
+    });
+
+    const normalizedProject = onProjectNormalized.mock.calls.at(
+      -1,
+    )![0] as Project;
+    const canonicalSeed = normalizedProject.assets.find(
+      (asset) => asset.id === sharedAssetBase.id,
+    )?.seedId;
+
+    expect(canonicalSeed).toBe('styled-seed');
+    expect(normalizedProject.secondaryTimeline?.masterAssets[0]?.seedId).toBe(
+      canonicalSeed,
+    );
+    expect(
+      normalizedProject.secondaryTimeline?.shotLists[0]?.shots[0]?.seedId,
+    ).toBe(canonicalSeed);
+    expect(normalizedProject.thirdTimeline?.styledShots[0]?.seedId).toBe(
+      canonicalSeed,
+    );
+    expect(normalizedProject.thirdTimeline?.batchStyleAssets?.[0]?.seedId).toBe(
+      canonicalSeed,
+    );
   });
 });

--- a/loop/src/hooks/useProject.ts
+++ b/loop/src/hooks/useProject.ts
@@ -18,12 +18,14 @@ const reindexBlocks = (blocks: TimelineBlock[]) =>
 
 const restoreBlocksWithPositions = (
   existingBlocks: TimelineBlock[],
-  restoredBlocks: TimelineBlock[]
+  restoredBlocks: TimelineBlock[],
 ) => {
-  const sortedRestored = [...restoredBlocks].sort((a, b) => a.position - b.position);
+  const sortedRestored = [...restoredBlocks].sort(
+    (a, b) => a.position - b.position,
+  );
   const mergedBlocks = [...existingBlocks];
 
-  sortedRestored.forEach(block => {
+  sortedRestored.forEach((block) => {
     const insertIndex = Math.min(block.position, mergedBlocks.length);
     mergedBlocks.splice(insertIndex, 0, { ...block });
   });
@@ -31,29 +33,132 @@ const restoreBlocksWithPositions = (
   return reindexBlocks(mergedBlocks);
 };
 
-const ensureAssetSeeds = <T extends Asset>(assets?: T[] | null): T[] | undefined => {
+const collectCanonicalSeeds = (project: Project): Map<string, string> => {
+  const canonicalSeeds = new Map<string, string>();
+  const awaitingSeeds = new Set<string>();
+
+  const registerAsset = (asset: Asset | undefined | null) => {
+    if (!asset) {
+      return;
+    }
+
+    const trimmedSeed = asset.seedId?.trim();
+    if (trimmedSeed) {
+      if (!canonicalSeeds.has(asset.id)) {
+        canonicalSeeds.set(asset.id, trimmedSeed);
+      }
+      awaitingSeeds.delete(asset.id);
+      return;
+    }
+
+    if (!canonicalSeeds.has(asset.id)) {
+      awaitingSeeds.add(asset.id);
+    }
+  };
+
+  const registerCollection = (assets: Asset[] | undefined | null) => {
+    if (!assets || assets.length === 0) {
+      return;
+    }
+
+    assets.forEach(registerAsset);
+  };
+
+  registerCollection(project.assets);
+
+  if (project.secondaryTimeline) {
+    registerCollection(project.secondaryTimeline.masterAssets);
+    project.secondaryTimeline.shotLists.forEach((shotList) => {
+      registerCollection(shotList.shots);
+    });
+  }
+
+  if (project.thirdTimeline) {
+    registerCollection(project.thirdTimeline.styledShots);
+    registerCollection(project.thirdTimeline.batchStyleAssets);
+  }
+
+  awaitingSeeds.forEach((assetId) => {
+    canonicalSeeds.set(assetId, crypto.randomUUID());
+  });
+
+  return canonicalSeeds;
+};
+
+const normalizeAssetSeed = <T extends Asset>(
+  asset: T,
+  canonicalSeeds: Map<string, string>,
+): T => {
+  const existingCanonical = canonicalSeeds.get(asset.id);
+
+  if (existingCanonical) {
+    if (asset.seedId === existingCanonical) {
+      return asset;
+    }
+
+    const trimmedSeed = asset.seedId?.trim();
+    if (trimmedSeed && trimmedSeed === existingCanonical) {
+      if (asset.seedId === existingCanonical) {
+        return asset;
+      }
+
+      return { ...asset, seedId: existingCanonical } as T;
+    }
+
+    return { ...asset, seedId: existingCanonical } as T;
+  }
+
+  const sanitizedSeed = asset.seedId?.trim();
+  const resolvedSeed =
+    sanitizedSeed && sanitizedSeed.length > 0
+      ? sanitizedSeed
+      : crypto.randomUUID();
+
+  canonicalSeeds.set(asset.id, resolvedSeed);
+
+  if (asset.seedId === resolvedSeed) {
+    return asset;
+  }
+
+  return { ...asset, seedId: resolvedSeed } as T;
+};
+
+const normalizeAssetCollection = <T extends Asset>(
+  assets: T[] | null | undefined,
+  canonicalSeeds: Map<string, string>,
+): T[] | undefined => {
   if (!assets) {
     return assets ?? undefined;
   }
 
-  const needsSeeds = assets.some(asset => !asset.seedId);
-  if (!needsSeeds) {
-    return assets;
-  }
+  let updatedAssets: T[] | undefined;
 
-  return assets.map(asset =>
-    asset.seedId ? asset : ({ ...asset, seedId: crypto.randomUUID() } as T)
-  );
+  assets.forEach((asset, index) => {
+    const normalizedAsset = normalizeAssetSeed(asset, canonicalSeeds);
+    if (normalizedAsset !== asset) {
+      if (!updatedAssets) {
+        updatedAssets = [...assets];
+      }
+
+      updatedAssets[index] = normalizedAsset;
+    }
+  });
+
+  return updatedAssets ?? assets;
 };
 
 const normalizeSeeds = (project: Project): Project => {
   let normalizedProject = project;
+  const canonicalSeeds = collectCanonicalSeeds(project);
 
-  const normalizedAssets = ensureAssetSeeds(project.assets)!;
+  const normalizedAssets = normalizeAssetCollection(
+    project.assets,
+    canonicalSeeds,
+  )!;
   if (normalizedAssets !== project.assets) {
     normalizedProject = {
       ...normalizedProject,
-      assets: normalizedAssets
+      assets: normalizedAssets,
     };
   }
 
@@ -61,17 +166,23 @@ const normalizeSeeds = (project: Project): Project => {
     const secondary = project.secondaryTimeline;
     let normalizedSecondary: typeof secondary | undefined;
 
-    const normalizedMasterAssets = ensureAssetSeeds(secondary.masterAssets)!;
+    const normalizedMasterAssets = normalizeAssetCollection(
+      secondary.masterAssets,
+      canonicalSeeds,
+    )!;
     if (normalizedMasterAssets !== secondary.masterAssets) {
       normalizedSecondary = {
         ...(normalizedSecondary ?? { ...secondary }),
-        masterAssets: normalizedMasterAssets
+        masterAssets: normalizedMasterAssets,
       };
     }
 
     let shotListsUpdated: typeof secondary.shotLists | undefined;
     secondary.shotLists.forEach((shotList, index) => {
-      const normalizedShots = ensureAssetSeeds(shotList.shots)!;
+      const normalizedShots = normalizeAssetCollection(
+        shotList.shots,
+        canonicalSeeds,
+      )!;
       if (normalizedShots !== shotList.shots) {
         if (!shotListsUpdated) {
           shotListsUpdated = [...secondary.shotLists];
@@ -83,14 +194,14 @@ const normalizeSeeds = (project: Project): Project => {
     if (shotListsUpdated) {
       normalizedSecondary = {
         ...(normalizedSecondary ?? { ...secondary }),
-        shotLists: shotListsUpdated
+        shotLists: shotListsUpdated,
       };
     }
 
     if (normalizedSecondary) {
       normalizedProject = {
         ...normalizedProject,
-        secondaryTimeline: normalizedSecondary
+        secondaryTimeline: normalizedSecondary,
       };
     }
   }
@@ -99,26 +210,35 @@ const normalizeSeeds = (project: Project): Project => {
     const third = project.thirdTimeline;
     let normalizedThird: typeof third | undefined;
 
-    const normalizedStyledShots = ensureAssetSeeds(third.styledShots)!;
+    const normalizedStyledShots = normalizeAssetCollection(
+      third.styledShots,
+      canonicalSeeds,
+    )!;
     if (normalizedStyledShots !== third.styledShots) {
       normalizedThird = {
         ...(normalizedThird ?? { ...third }),
-        styledShots: normalizedStyledShots
+        styledShots: normalizedStyledShots,
       };
     }
 
-    const normalizedBatchAssets = ensureAssetSeeds(third.batchStyleAssets);
-    if (normalizedBatchAssets && normalizedBatchAssets !== third.batchStyleAssets) {
+    const normalizedBatchAssets = normalizeAssetCollection(
+      third.batchStyleAssets,
+      canonicalSeeds,
+    );
+    if (
+      normalizedBatchAssets &&
+      normalizedBatchAssets !== third.batchStyleAssets
+    ) {
       normalizedThird = {
         ...(normalizedThird ?? { ...third }),
-        batchStyleAssets: normalizedBatchAssets
+        batchStyleAssets: normalizedBatchAssets,
       };
     }
 
     if (normalizedThird) {
       normalizedProject = {
         ...normalizedProject,
-        thirdTimeline: normalizedThird
+        thirdTimeline: normalizedThird,
       };
     }
   }
@@ -127,147 +247,182 @@ const normalizeSeeds = (project: Project): Project => {
 };
 
 export const useProject = (initialProject: Project) => {
-  const [project, setProjectState] = useState<Project>(() => normalizeSeeds(initialProject));
+  const [project, setProjectState] = useState<Project>(() =>
+    normalizeSeeds(initialProject),
+  );
   const setProject = useCallback(
     (update: SetStateAction<Project>) => {
-      setProjectState(prev => {
-        const next = typeof update === 'function'
-          ? (update as (value: Project) => Project)(prev)
-          : update;
+      setProjectState((prev) => {
+        const next =
+          typeof update === 'function'
+            ? (update as (value: Project) => Project)(prev)
+            : update;
         return normalizeSeeds(next);
       });
     },
-    [setProjectState]
+    [setProjectState],
   );
   const [selectedAssetId, setSelectedAssetId] = useState<string | null>(null);
-  const [pendingDeleteAsset, setPendingDeleteAsset] = useState<Asset | null>(null);
+  const [pendingDeleteAsset, setPendingDeleteAsset] = useState<Asset | null>(
+    null,
+  );
   const [undoState, setUndoState] = useState<UndoState | null>(null);
   const [toastState, setToastState] = useState<ToastState | null>(null);
   const [selectedStoryAssets, setSelectedStoryAssets] = useState<string[]>([]);
   const [selectedMultiShots, setSelectedMultiShots] = useState<string[]>([]);
-  const [selectedMasterImage, setSelectedMasterImage] = useState<string | null>(null);
-  const [activeTimeline, setActiveTimeline] = useState<'primary' | 'secondary' | 'third' | 'fourth'>('primary');
+  const [selectedMasterImage, setSelectedMasterImage] = useState<string | null>(
+    null,
+  );
+  const [activeTimeline, setActiveTimeline] = useState<
+    'primary' | 'secondary' | 'third' | 'fourth'
+  >('primary');
   const [isGenerating, setIsGenerating] = useState(false);
 
-  const handleAddAsset = useCallback((templateType: string) => {
-    const template = ASSET_TEMPLATES[templateType];
-    if (!template) return;
+  const handleAddAsset = useCallback(
+    (templateType: string) => {
+      const template = ASSET_TEMPLATES[templateType];
+      if (!template) return;
 
-    const newAsset: Asset = {
-      id: crypto.randomUUID(),
-      seedId: crypto.randomUUID(),
-      type: template.type,
-      name: `New ${template.name}`,
-      content: template.defaultContent || '',
-      tags: template.tags || [],
-      createdAt: new Date(),
-      summary: '',
-      isMaster: false,
-      lineage: [],
-      metadata: {}
-    };
-
-    const newBlock: TimelineBlock = {
-      id: crypto.randomUUID(),
-      assetId: newAsset.id,
-      position: 0 // This will be re-indexed
-    };
-
-    setProject(prev => {
-      const folderKey = template.category === 'visual' ? 'image' : 'story';
-      const targetFolder = prev.primaryTimeline.folders[folderKey] || [];
-      
-      return {
-        ...prev,
-        assets: [...prev.assets, newAsset],
-        primaryTimeline: {
-          ...prev.primaryTimeline,
-          folders: {
-            ...prev.primaryTimeline.folders,
-            [folderKey]: reindexBlocks([...targetFolder, newBlock])
-          }
-        },
-        updatedAt: new Date()
+      const newAsset: Asset = {
+        id: crypto.randomUUID(),
+        seedId: crypto.randomUUID(),
+        type: template.type,
+        name: `New ${template.name}`,
+        content: template.defaultContent || '',
+        tags: template.tags || [],
+        createdAt: new Date(),
+        summary: '',
+        isMaster: false,
+        lineage: [],
+        metadata: {},
       };
-    });
 
-    setSelectedAssetId(newAsset.id);
-  }, [setProject, setSelectedAssetId]);
+      const newBlock: TimelineBlock = {
+        id: crypto.randomUUID(),
+        assetId: newAsset.id,
+        position: 0, // This will be re-indexed
+      };
 
-  const handleAssetDrop = useCallback((templateType: string, folder: string = 'story') => {
-    handleAddAsset(templateType);
-  }, [handleAddAsset]);
+      setProject((prev) => {
+        const folderKey = template.category === 'visual' ? 'image' : 'story';
+        const targetFolder = prev.primaryTimeline.folders[folderKey] || [];
 
-  const performAssetRemoval = useCallback((asset: Asset) => {
-    let assetRemoved = false;
+        return {
+          ...prev,
+          assets: [...prev.assets, newAsset],
+          primaryTimeline: {
+            ...prev.primaryTimeline,
+            folders: {
+              ...prev.primaryTimeline.folders,
+              [folderKey]: reindexBlocks([...targetFolder, newBlock]),
+            },
+          },
+          updatedAt: new Date(),
+        };
+      });
 
-    setProject(prev => {
-      const existingAsset = prev.assets.find(existing => existing.id === asset.id);
-      if (!existingAsset) {
-        return prev;
-      }
+      setSelectedAssetId(newAsset.id);
+    },
+    [setProject, setSelectedAssetId],
+  );
 
-      assetRemoved = true;
+  const handleAssetDrop = useCallback(
+    (templateType: string, folder: string = 'story') => {
+      handleAddAsset(templateType);
+    },
+    [handleAddAsset],
+  );
 
-      const removedBlocks = prev.primaryTimeline.blocks
-        .filter(block => block.assetId === asset.id)
-        .map(block => ({ ...block }));
+  const performAssetRemoval = useCallback(
+    (asset: Asset) => {
+      let assetRemoved = false;
 
-      const remainingBlocks = reindexBlocks(
-        prev.primaryTimeline.blocks
-          .filter(block => block.assetId !== asset.id)
-          .map(block => ({ ...block }))
-      );
+      setProject((prev) => {
+        const existingAsset = prev.assets.find(
+          (existing) => existing.id === asset.id,
+        );
+        if (!existingAsset) {
+          return prev;
+        }
 
-      const removedFolderAssignments: UndoState['folderAssignments'] = [];
-      const updatedFoldersEntries = Object.entries(prev.primaryTimeline.folders).map(([folderKey, blocks]) => {
-        const keptBlocks: TimelineBlock[] = [];
+        assetRemoved = true;
 
-        blocks.forEach(block => {
-          if (block.assetId === asset.id) {
-            removedFolderAssignments.push({ folder: folderKey, block: { ...block } });
-          } else {
-            keptBlocks.push({ ...block });
-          }
+        const removedBlocks = prev.primaryTimeline.blocks
+          .filter((block) => block.assetId === asset.id)
+          .map((block) => ({ ...block }));
+
+        const remainingBlocks = reindexBlocks(
+          prev.primaryTimeline.blocks
+            .filter((block) => block.assetId !== asset.id)
+            .map((block) => ({ ...block })),
+        );
+
+        const removedFolderAssignments: UndoState['folderAssignments'] = [];
+        const updatedFoldersEntries = Object.entries(
+          prev.primaryTimeline.folders,
+        ).map(([folderKey, blocks]) => {
+          const keptBlocks: TimelineBlock[] = [];
+
+          blocks.forEach((block) => {
+            if (block.assetId === asset.id) {
+              removedFolderAssignments.push({
+                folder: folderKey,
+                block: { ...block },
+              });
+            } else {
+              keptBlocks.push({ ...block });
+            }
+          });
+
+          return [folderKey, reindexBlocks(keptBlocks)] as [
+            string,
+            TimelineBlock[],
+          ];
         });
 
-        return [folderKey, reindexBlocks(keptBlocks)] as [string, TimelineBlock[]];
+        const updatedFolders = Object.fromEntries(
+          updatedFoldersEntries,
+        ) as typeof prev.primaryTimeline.folders;
+
+        setUndoState({
+          asset,
+          blocks: removedBlocks,
+          folderAssignments: removedFolderAssignments,
+        });
+
+        return {
+          ...prev,
+          assets: prev.assets.filter((existing) => existing.id !== asset.id),
+          primaryTimeline: {
+            ...prev.primaryTimeline,
+            blocks: remainingBlocks,
+            folders: updatedFolders,
+          },
+          updatedAt: new Date(),
+        };
       });
 
-      const updatedFolders = Object.fromEntries(updatedFoldersEntries) as typeof prev.primaryTimeline.folders;
+      if (assetRemoved) {
+        setSelectedAssetId((prevSelected) =>
+          prevSelected === asset.id ? null : prevSelected,
+        );
+        setToastState({
+          id: crypto.randomUUID(),
+          message: `Removed "${asset.name}"`,
+          allowUndo: true,
+          kind: 'warning',
+        });
+      }
+    },
+    [setProject, setSelectedAssetId, setToastState, setUndoState],
+  );
 
-      setUndoState({
-        asset,
-        blocks: removedBlocks,
-        folderAssignments: removedFolderAssignments
-      });
-
-      return {
-        ...prev,
-        assets: prev.assets.filter(existing => existing.id !== asset.id),
-        primaryTimeline: {
-          ...prev.primaryTimeline,
-          blocks: remainingBlocks,
-          folders: updatedFolders
-        },
-        updatedAt: new Date()
-      };
-    });
-
-    if (assetRemoved) {
-      setSelectedAssetId(prevSelected => (prevSelected === asset.id ? null : prevSelected));
-      setToastState({
-        id: crypto.randomUUID(),
-        message: `Removed "${asset.name}"`,
-        allowUndo: true,
-        kind: 'warning'
-      });
-    }
-  }, [setProject, setSelectedAssetId, setToastState, setUndoState]);
-
-  const handleRequestDeleteAsset = useCallback((asset: Asset) => {
-    setPendingDeleteAsset(asset);
-  }, [setPendingDeleteAsset]);
+  const handleRequestDeleteAsset = useCallback(
+    (asset: Asset) => {
+      setPendingDeleteAsset(asset);
+    },
+    [setPendingDeleteAsset],
+  );
 
   const handleConfirmDelete = useCallback(() => {
     if (!pendingDeleteAsset) return;
@@ -284,41 +439,53 @@ export const useProject = (initialProject: Project) => {
 
     const stateToRestore = undoState;
 
-    setProject(prev => {
-      if (prev.assets.some(existing => existing.id === stateToRestore.asset.id)) {
+    setProject((prev) => {
+      if (
+        prev.assets.some((existing) => existing.id === stateToRestore.asset.id)
+      ) {
         return prev;
       }
 
       const restoredBlocks = restoreBlocksWithPositions(
-        prev.primaryTimeline.blocks.map(block => ({ ...block })),
-        stateToRestore.blocks
+        prev.primaryTimeline.blocks.map((block) => ({ ...block })),
+        stateToRestore.blocks,
       );
 
-      const assignmentsByFolder = stateToRestore.folderAssignments.reduce((acc, assignment) => {
-        if (!acc[assignment.folder]) {
-          acc[assignment.folder] = [];
-        }
-        acc[assignment.folder].push({ ...assignment.block });
-        return acc;
-      }, {} as Record<string, TimelineBlock[]>);
+      const assignmentsByFolder = stateToRestore.folderAssignments.reduce(
+        (acc, assignment) => {
+          if (!acc[assignment.folder]) {
+            acc[assignment.folder] = [];
+          }
+          acc[assignment.folder].push({ ...assignment.block });
+          return acc;
+        },
+        {} as Record<string, TimelineBlock[]>,
+      );
 
-      const restoredFoldersEntries = Object.entries(prev.primaryTimeline.folders).map(([folderKey, blocks]) => {
+      const restoredFoldersEntries = Object.entries(
+        prev.primaryTimeline.folders,
+      ).map(([folderKey, blocks]) => {
         const restoredForFolder = assignmentsByFolder[folderKey] || [];
         delete assignmentsByFolder[folderKey];
         return [
           folderKey,
-          restoreBlocksWithPositions(blocks.map(block => ({ ...block })), restoredForFolder)
+          restoreBlocksWithPositions(
+            blocks.map((block) => ({ ...block })),
+            restoredForFolder,
+          ),
         ] as [string, TimelineBlock[]];
       });
 
       Object.entries(assignmentsByFolder).forEach(([folderKey, blocks]) => {
         restoredFoldersEntries.push([
           folderKey,
-          restoreBlocksWithPositions([], blocks)
+          restoreBlocksWithPositions([], blocks),
         ]);
       });
 
-      const restoredFolders = Object.fromEntries(restoredFoldersEntries) as typeof prev.primaryTimeline.folders;
+      const restoredFolders = Object.fromEntries(
+        restoredFoldersEntries,
+      ) as typeof prev.primaryTimeline.folders;
 
       return {
         ...prev,
@@ -326,9 +493,9 @@ export const useProject = (initialProject: Project) => {
         primaryTimeline: {
           ...prev.primaryTimeline,
           blocks: restoredBlocks,
-          folders: restoredFolders
+          folders: restoredFolders,
         },
-        updatedAt: new Date()
+        updatedAt: new Date(),
       };
     });
 
@@ -337,28 +504,37 @@ export const useProject = (initialProject: Project) => {
     setToastState({
       id: crypto.randomUUID(),
       message: `Restored "${stateToRestore.asset.name}"`,
-      kind: 'success'
+      kind: 'success',
     });
   }, [undoState, setProject, setSelectedAssetId, setToastState]);
 
   const handleUpdateAsset = (assetId: string, updates: Partial<Asset>) => {
-    setProject(prev => ({
-        ...prev,
-        assets: prev.assets.map(asset => asset.id === assetId ? { ...asset, ...updates, updatedAt: new Date() } : asset)
+    setProject((prev) => ({
+      ...prev,
+      assets: prev.assets.map((asset) =>
+        asset.id === assetId
+          ? { ...asset, ...updates, updatedAt: new Date() }
+          : asset,
+      ),
     }));
   };
 
   const handleGenerateOutput = async (folder: 'story' | 'image' | 'all') => {
     setIsGenerating(true);
-    setToastState({ id: crypto.randomUUID(), message: 'Generating master assets...', kind: 'info' });
+    setToastState({
+      id: crypto.randomUUID(),
+      message: 'Generating master assets...',
+      kind: 'info',
+    });
 
     const workspace = {
       assets: project.assets,
-      canvas: { nodes: [], connections: [] }
+      canvas: { nodes: [], connections: [] },
     };
 
     const runGeneration = async (target: 'story' | 'image') => {
-      const outputType = target === 'story' ? 'Master Story' : 'Master Visual Style';
+      const outputType =
+        target === 'story' ? 'Master Story' : 'Master Visual Style';
       const result = await generateFromWorkspace(workspace, {}, 50, outputType);
 
       if (result.data && !result.error) {
@@ -375,39 +551,45 @@ export const useProject = (initialProject: Project) => {
           createdAt: now,
           summary: `Generated master ${target === 'story' ? 'story' : 'visual style'} asset.`,
           isMaster: true,
-          lineage: project.primaryTimeline.folders[sourceFolder as keyof typeof project.primaryTimeline.folders]?.map(block => block.assetId) || [],
+          lineage:
+            project.primaryTimeline.folders[
+              sourceFolder as keyof typeof project.primaryTimeline.folders
+            ]?.map((block) => block.assetId) || [],
           metadata: {
             generatedAt: now.toISOString(),
-            outputType
-          }
+            outputType,
+          },
         };
 
-        setProject(prev => {
+        setProject((prev) => {
           const updatedAssets = [...prev.assets, newMasterAsset];
 
           if (target === 'story') {
             const existingSecondary = prev.secondaryTimeline ?? {
               masterAssets: [],
               shotLists: [],
-              appliedStyles: {}
+              appliedStyles: {},
             };
 
             return {
               ...prev,
               assets: updatedAssets,
               secondaryTimeline: {
-                masterAssets: [...(existingSecondary.masterAssets || []), newMasterAsset],
+                masterAssets: [
+                  ...(existingSecondary.masterAssets || []),
+                  newMasterAsset,
+                ],
                 shotLists: [...(existingSecondary.shotLists || [])],
-                appliedStyles: existingSecondary.appliedStyles
+                appliedStyles: existingSecondary.appliedStyles,
               },
-              updatedAt: now
+              updatedAt: now,
             };
           }
 
           const existingThird = prev.thirdTimeline ?? {
             styledShots: [],
             videoPrompts: [],
-            batchStyleAssets: []
+            batchStyleAssets: [],
           };
 
           return {
@@ -416,16 +598,16 @@ export const useProject = (initialProject: Project) => {
             thirdTimeline: {
               styledShots: [...(existingThird.styledShots || [])],
               videoPrompts: [...(existingThird.videoPrompts || [])],
-              batchStyleAssets: [...(existingThird.batchStyleAssets || [])]
+              batchStyleAssets: [...(existingThird.batchStyleAssets || [])],
             },
-            updatedAt: now
+            updatedAt: now,
           };
         });
 
         setToastState({
           id: crypto.randomUUID(),
           message: `Master ${target === 'story' ? 'story' : 'visual'} asset generated successfully!`,
-          kind: 'success'
+          kind: 'success',
         });
         setActiveTimeline(target === 'story' ? 'secondary' : 'third');
 
@@ -435,7 +617,7 @@ export const useProject = (initialProject: Project) => {
       setToastState({
         id: crypto.randomUUID(),
         message: `Generation failed: ${result.error || 'Unknown error'}`,
-        kind: 'error'
+        kind: 'error',
       });
       return false;
     };
@@ -479,6 +661,6 @@ export const useProject = (initialProject: Project) => {
     setActiveTimeline,
     isGenerating,
     handleGenerate,
-    handleGenerateOutput
+    handleGenerateOutput,
   };
 };


### PR DESCRIPTION
## Summary
- tighten project seed normalization so canonical IDs are collected before reusing them across every asset collection
- mock the API config module inside the timeline modal tests and extend coverage to ensure shared assets keep the same seed in each timeline

## Testing
- npx vitest run loop/src/components/__tests__/TimelineModals.test.tsx
- npm run --prefix loop build

------
https://chatgpt.com/codex/tasks/task_e_68e64e658eb48326bcdf97a75242102c